### PR TITLE
Add option to download taxon data from GitHub if missing

### DIFF
--- a/naturtag/constants.py
+++ b/naturtag/constants.py
@@ -10,7 +10,7 @@ PKG_DIR = Path(__file__).parent.parent
 ASSETS_DIR = PKG_DIR / 'assets'
 ICONS_DIR = ASSETS_DIR / 'icons'
 CLI_COMPLETE_DIR = ASSETS_DIR / 'autocomplete'
-PACKAGED_DB = ASSETS_DIR / 'taxonomy.tar.gz'
+PACKAGED_TAXON_DB = ASSETS_DIR / 'taxonomy.tar.gz'
 APP_ICON = ICONS_DIR / 'logo.ico'
 APP_LOGO = ICONS_DIR / 'logo.png'
 SPINNER = ICONS_DIR / 'spinner_250px.svg'
@@ -26,6 +26,7 @@ USER_TAXA_PATH = APP_DIR / 'stored_taxa.yml'
 # Project info
 DOCS_URL = 'https://naturtag.readthedocs.io/en/latest/app.html'
 REPO_URL = 'https://github.com/pyinat/naturtag'
+TAXON_DB_URL = 'https://github.com/pyinat/naturtag/raw/main/assets/taxonomy.tar.gz'
 
 # Thumnbnail settings
 IMAGE_FILETYPES = ['*.jpg', '*.jpeg', '*.png', '*.gif', '*.webp']


### PR DESCRIPTION
Taxonomy data is included with PyInstaller packages and platform-specific installers, but not with the plain python package on PyPI (to keep package size small). This adds an option to download the missing data:
```python
from naturtag.settings import setup

setup(overwrite=True, download=True)
```

I may later include this as an option in the CLI and GUI, but need to think about it some more. In particular, whether having the option to download and extract something is a potential security risk. Basically the process is:
* Download a ~11MB `.tar.gz` archive from GitHub
* Extract into `.csv` files
* Load `.csv` files into a SQLite database

No scripts or other executable files are downloaded.