### PR TITLE
General UI improvements

### DIFF
--- a/assets/style.qss
+++ b/assets/style.qss
@@ -1,16 +1,16 @@
 QGroupBox {
-    font: bold 16pt;
+    font: bold 14pt;
     border: 2px solid palette(midlight);
     border-radius: 6px;
     margin-top: 10px;
     padding:5px;
 }
-QGroupBox::title {
+/* QGroupBox::title {
     subcontrol-origin:  margin;
     subcontrol-position: top left;
     left: 7px;
     padding: 0px 5px 0px 5px;
-}
+} */
 QScrollArea {
     background: palette(midlight);
 }
@@ -20,15 +20,12 @@ InfoCard {
     border-radius: 6px;
 }
 InfoCard:hover {
-    background: palette(dark);
+    background: rgba(46, 70, 94, 0.33);
 }
 InfoCardList {
     background: palette(alternate-base);
 }
 
-ThumbnailCard {
-    background: palette(base);
-}
 ThumbnailCard > QLabel {
     background-color: rgba(0, 0, 0, 0.3);
     font-size: 11pt;
@@ -38,9 +35,9 @@ ThumbnailCard > QLabel#metadata-icons {
     font-size: 11pt;
 }
 
-StylableWidget#gallery_scroll_panel {
+/* StylableWidget#gallery_scroll_panel {
     background: palette(base);
-}
+} */
 
 QLabel#hover_overlay {
     background-color: rgba(0, 0, 0, 0.3);
@@ -52,7 +49,10 @@ QLabel#h1_italic {
     font: bold italic 16pt;
 }
 QLabel#h2 {
-    font: bold 14pt;
+    font: bold 13pt;
+}
+QLabel#h2_italic {
+    font: bold italic 13pt;
 }
 QLabel#h3 {
     font: bold 12pt;

--- a/assets/style.qss
+++ b/assets/style.qss
@@ -30,7 +30,7 @@ ThumbnailCard > QLabel {
     background-color: rgba(0, 0, 0, 0.3);
     font-size: 11pt;
 }
-ThumbnailCard > QLabel#metadata-icons {
+ThumbnailCard > QLabel#metadata_icons {
     background-color: rgba(0, 0, 0, 0.5);
     font-size: 11pt;
 }

--- a/assets/style.qss
+++ b/assets/style.qss
@@ -20,7 +20,7 @@ InfoCard {
     border-radius: 6px;
 }
 InfoCard:hover {
-    background: rgba(46, 70, 94, 0.33);
+    background: palette(link-visited);
 }
 InfoCardList {
     background: palette(alternate-base);

--- a/naturtag/app/app.py
+++ b/naturtag/app/app.py
@@ -17,11 +17,10 @@ from PySide6.QtWidgets import (
     QTabWidget,
     QWidget,
 )
-from qtmodern.windows import ModernWindow
 
 from naturtag.app.controls import Toolbar, UserDirs
 from naturtag.app.settings_menu import SettingsMenu
-from naturtag.app.style import fa_icon, set_stylesheet, set_theme
+from naturtag.app.style import fa_icon, set_theme
 from naturtag.app.threadpool import ThreadPool
 from naturtag.constants import APP_DIR, APP_ICON, APP_LOGO, ASSETS_DIR, DOCS_URL, REPO_URL
 from naturtag.controllers import ImageController, ObservationController, TaxonController
@@ -199,7 +198,7 @@ class MainWindow(QMainWindow):
 
     def reload_qss(self):
         """Reload Qt stylesheet"""
-        set_stylesheet(self)
+        set_theme(dark_mode=self.settings.dark_mode)
 
     def show_settings(self):
         """Show the settings menu"""
@@ -230,7 +229,7 @@ def main():
 
     app.setWindowIcon(QIcon(QPixmap(str(APP_ICON))))
     set_theme(dark_mode=settings.dark_mode)
-    window = ModernWindow(MainWindow(settings))
+    window = MainWindow(settings)
     window.show()
     splash.finish(window)
     sys.exit(app.exec())

--- a/naturtag/app/style.py
+++ b/naturtag/app/style.py
@@ -1,9 +1,9 @@
 from logging import getLogger
 
+import qdarktheme
 from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QApplication
 from qtawesome import icon
-from qtmodern.styles import _STYLESHEET as BASE_STYLESHEET
 
 from naturtag.constants import QSS_PATH
 
@@ -35,24 +35,18 @@ def fa_icon(icon_name, secondary: bool = False, **kwargs):
     )
 
 
-def set_stylesheet(obj=None):
-    obj = obj or QApplication.instance()
-    logger.debug(f'Loading stylesheet: {QSS_PATH}')
-
-    with open(BASE_STYLESHEET) as f:
-        obj.setStyleSheet(f.read())
-    with open(QSS_PATH) as f:
-        obj.setStyleSheet(f.read())
-
-
 def set_theme(dark_mode: bool = True):
-    logger.debug(f"Setting theme: {'dark' if dark_mode else 'light'}")
-    palette = dark_palette() if dark_mode else light_palette()
-
     app = QApplication.instance()
-    app.setStyle('Fusion')
+    theme_str = 'dark' if dark_mode else 'light'
+    logger.debug(f'Setting theme: {theme_str}')
+
+    palette = qdarktheme.load_palette(theme_str)
     app.setPalette(palette)
-    set_stylesheet()
+
+    base_stylesheet = qdarktheme.load_stylesheet(theme=theme_str)
+    with open(QSS_PATH) as f:
+        extra_stylesheet = f.read()
+    app.setStyleSheet(base_stylesheet + '\n' + extra_stylesheet)
 
 
 def dark_palette() -> QPalette:

--- a/naturtag/app/style.py
+++ b/naturtag/app/style.py
@@ -7,14 +7,15 @@ from qtawesome import icon
 
 from naturtag.constants import QSS_PATH
 
-YELLOWGREEN = (154, 205, 50)
-YELLOWGREEN_DARK = (130, 195, 45)
-PALEBLUE = (128, 207, 238)
-PALEBLUE_DARK = (98, 190, 227)
-GRAYBLUE = (63, 113, 172)
-SILVER = (173, 168, 182)
+CustomPalette = dict[QPalette.ColorRole, str]
 
-# LIGHT_GREEN_INAT = (116, 172, 0)
+YELLOWGREEN = '#9acd32'
+YELLOWGREEN_DARK = '#82c32d'
+PALEBLUE = '#80cfee'
+PALEBLUE_DARK = '#62bee3'
+
+# GRAYBLUE = (63, 113, 172)
+# SILVER = (173, 168, 182)
 # PRPL = (200, 0, 200)
 # LAVENDER = (180, 180, 255)
 # UMBER = (95, 84, 73)
@@ -41,6 +42,10 @@ def set_theme(dark_mode: bool = True):
     logger.debug(f'Setting theme: {theme_str}')
 
     palette = qdarktheme.load_palette(theme_str)
+    if dark_mode:
+        palette = mod_dark_palette(palette)
+    else:
+        palette = mod_light_palette(palette)
     app.setPalette(palette)
 
     base_stylesheet = qdarktheme.load_stylesheet(theme=theme_str)
@@ -49,80 +54,60 @@ def set_theme(dark_mode: bool = True):
     app.setStyleSheet(base_stylesheet + '\n' + extra_stylesheet)
 
 
-def dark_palette() -> QPalette:
-    base = {
-        QPalette.AlternateBase: (66, 66, 66),
-        QPalette.Base: (42, 42, 42),
-        QPalette.BrightText: (180, 180, 180),
-        QPalette.Button: (53, 53, 53),
-        QPalette.ButtonText: (180, 180, 180),
-        QPalette.Dark: (35, 35, 35),
+def mod_dark_palette(palette: QPalette) -> QPalette:
+    enabled = {
+        # QPalette.AlternateBase: (66, 66, 66),
+        # QPalette.Base: (42, 42, 42),
+        # QPalette.BrightText: (180, 180, 180),
+        # QPalette.Button: (53, 53, 53),
+        # QPalette.ButtonText: (180, 180, 180),
+        # QPalette.Dark: (35, 35, 35),
         # QPalette.Highlight: (42, 130, 218),
         QPalette.Highlight: PALEBLUE,
-        QPalette.HighlightedText: (180, 180, 180),
-        QPalette.Light: (180, 180, 180),
+        # QPalette.HighlightedText: (180, 180, 180),
+        # QPalette.Light: (180, 180, 180),
         QPalette.Link: YELLOWGREEN,  # Secondary highlight
-        QPalette.LinkVisited: (80, 80, 80),
-        QPalette.Midlight: (90, 90, 90),
-        # QPalette.Midlight: CERULEAN,
-        QPalette.Shadow: (20, 20, 20),
-        QPalette.Text: (180, 180, 180),
-        QPalette.ToolTipBase: (53, 53, 53),
-        QPalette.ToolTipText: (180, 180, 180),
-        # QPalette.ToolTipText: LAVENDER,
-        QPalette.Window: (53, 53, 53),
-        QPalette.WindowText: (180, 180, 180),
-        # QPalette.WindowText: PRPL,
+        # QPalette.LinkVisited: (80, 80, 80),
+        # QPalette.Midlight: (90, 90, 90),
+        # QPalette.Shadow: (20, 20, 20),
+        # QPalette.Text: (180, 180, 180),
+        # QPalette.ToolTipBase: (53, 53, 53),
+        # QPalette.ToolTipText: (180, 180, 180),
+        # QPalette.Window: (53, 53, 53),
+        # QPalette.WindowText: (180, 180, 180),
     }
-    disabled = {
-        QPalette.ButtonText: (127, 127, 127),
-        QPalette.Highlight: (80, 80, 80),
-        QPalette.HighlightedText: (127, 127, 127),
-        QPalette.Text: (127, 127, 127),
-        QPalette.WindowText: (127, 127, 127),
-    }
-
-    palette = QPalette()
-    for role, rgb in base.items():
-        palette.setColor(role, QColor(*rgb))
-    for role, rgb in disabled.items():
-        palette.setColor(QPalette.Disabled, role, QColor(*rgb))
-    return palette
+    disabled: CustomPalette = {}
+    return _modify_palette(palette, enabled, disabled)
 
 
-def light_palette() -> QPalette:
-    base = {
-        QPalette.AlternateBase: (245, 245, 245),
-        QPalette.Base: (237, 237, 237),
-        QPalette.BrightText: (0, 0, 0),
-        QPalette.Button: (240, 240, 240),
-        QPalette.ButtonText: (0, 0, 0),
-        QPalette.Dark: (225, 225, 225),
-        # QPalette.Highlight: (76, 163, 224),
+def mod_light_palette(palette) -> QPalette:
+    enabled = {
+        # QPalette.AlternateBase: (245, 245, 245),
+        # QPalette.Base: (237, 237, 237),
+        # QPalette.BrightText: (0, 0, 0),
+        # QPalette.Button: (240, 240, 240),
+        # QPalette.ButtonText: (0, 0, 0),
+        # QPalette.Dark: (225, 225, 225),
         QPalette.Highlight: PALEBLUE_DARK,
-        QPalette.HighlightedText: (0, 0, 0),
-        QPalette.Light: (180, 180, 180),
+        # QPalette.HighlightedText: (0, 0, 0),
+        # QPalette.Light: (180, 180, 180),
         QPalette.Link: YELLOWGREEN,
-        QPalette.LinkVisited: (222, 222, 222),
-        QPalette.Midlight: (200, 200, 200),
-        QPalette.Shadow: (20, 20, 20),
-        QPalette.Text: (0, 0, 0),
-        QPalette.ToolTipBase: (240, 240, 240),
-        QPalette.ToolTipText: (0, 0, 0),
-        QPalette.Window: (240, 240, 240),
-        QPalette.WindowText: (0, 0, 0),
+        # QPalette.LinkVisited: (222, 222, 222),
+        # QPalette.Midlight: (200, 200, 200),
+        # QPalette.Shadow: (20, 20, 20),
+        # QPalette.Text: (0, 0, 0),
+        # QPalette.ToolTipBase: (240, 240, 240),
+        # QPalette.ToolTipText: (0, 0, 0),
+        # QPalette.Window: (240, 240, 240),
+        # QPalette.WindowText: (0, 0, 0),
     }
-    disabled = {
-        QPalette.WindowText: (115, 115, 115),
-        QPalette.Text: (115, 115, 115),
-        QPalette.ButtonText: (115, 115, 115),
-        QPalette.Highlight: (190, 190, 190),
-        QPalette.HighlightedText: (115, 115, 115),
-    }
+    disabled: CustomPalette = {}
+    return _modify_palette(palette, enabled, disabled)
 
-    palette = QPalette()
-    for role, rgb in base.items():
-        palette.setColor(role, QColor(*rgb))
-    for role, rgb in disabled.items():
-        palette.setColor(QPalette.Disabled, role, QColor(*rgb))
+
+def _modify_palette(palette: QPalette, enabled: CustomPalette, disabled: CustomPalette) -> QPalette:
+    for role, color_str in enabled.items():
+        palette.setColor(role, QColor(color_str))
+    for role, color_str in disabled.items():
+        palette.setColor(QPalette.Disabled, role, QColor(color_str))
     return palette

--- a/naturtag/app/style.py
+++ b/naturtag/app/style.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import Union
 
 import qdarktheme
 from PySide6.QtGui import QColor, QPalette
@@ -7,7 +8,7 @@ from qtawesome import icon
 
 from naturtag.constants import QSS_PATH
 
-CustomPalette = dict[QPalette.ColorRole, str]
+CustomPalette = dict[QPalette.ColorRole, Union[str, tuple]]
 
 YELLOWGREEN = '#9acd32'
 YELLOWGREEN_DARK = '#82c32d'
@@ -55,7 +56,7 @@ def set_theme(dark_mode: bool = True):
 
 
 def mod_dark_palette(palette: QPalette) -> QPalette:
-    enabled = {
+    enabled: CustomPalette = {
         # QPalette.AlternateBase: (66, 66, 66),
         # QPalette.Base: (42, 42, 42),
         # QPalette.BrightText: (180, 180, 180),
@@ -67,7 +68,7 @@ def mod_dark_palette(palette: QPalette) -> QPalette:
         # QPalette.HighlightedText: (180, 180, 180),
         # QPalette.Light: (180, 180, 180),
         QPalette.Link: YELLOWGREEN,  # Secondary highlight
-        # QPalette.LinkVisited: (80, 80, 80),
+        QPalette.LinkVisited: (46, 70, 94, 85),  # Hover highlight
         # QPalette.Midlight: (90, 90, 90),
         # QPalette.Shadow: (20, 20, 20),
         # QPalette.Text: (180, 180, 180),
@@ -81,7 +82,7 @@ def mod_dark_palette(palette: QPalette) -> QPalette:
 
 
 def mod_light_palette(palette) -> QPalette:
-    enabled = {
+    enabled: CustomPalette = {
         # QPalette.AlternateBase: (245, 245, 245),
         # QPalette.Base: (237, 237, 237),
         # QPalette.BrightText: (0, 0, 0),
@@ -92,7 +93,7 @@ def mod_light_palette(palette) -> QPalette:
         # QPalette.HighlightedText: (0, 0, 0),
         # QPalette.Light: (180, 180, 180),
         QPalette.Link: YELLOWGREEN,
-        # QPalette.LinkVisited: (222, 222, 222),
+        QPalette.LinkVisited: (181, 202, 244, 85),
         # QPalette.Midlight: (200, 200, 200),
         # QPalette.Shadow: (20, 20, 20),
         # QPalette.Text: (0, 0, 0),
@@ -106,8 +107,11 @@ def mod_light_palette(palette) -> QPalette:
 
 
 def _modify_palette(palette: QPalette, enabled: CustomPalette, disabled: CustomPalette) -> QPalette:
-    for role, color_str in enabled.items():
-        palette.setColor(role, QColor(color_str))
-    for role, color_str in disabled.items():
-        palette.setColor(QPalette.Disabled, role, QColor(color_str))
+    def _get_qcolor(color):
+        return QColor(*color) if isinstance(color, tuple) else QColor(color)
+
+    for role, color in enabled.items():
+        palette.setColor(role, _get_qcolor(color))
+    for role, color in disabled.items():
+        palette.setColor(QPalette.Disabled, role, _get_qcolor(color))
     return palette

--- a/naturtag/constants.py
+++ b/naturtag/constants.py
@@ -31,7 +31,7 @@ TAXON_DB_URL = 'https://github.com/pyinat/naturtag/raw/main/assets/taxonomy.tar.
 # Thumnbnail settings
 IMAGE_FILETYPES = ['*.jpg', '*.jpeg', '*.png', '*.gif', '*.webp']
 PHOTO_SIZES = ['square', 'small', 'medium', 'large', 'original']
-SIZE_ICON_SM = (20, 20)
+SIZE_ICON_SM = (22, 22)
 SIZE_ICON = (32, 32)
 SIZE_SM = (75, 75)
 SIZE_DEFAULT = (250, 250)

--- a/naturtag/controllers/image_gallery.py
+++ b/naturtag/controllers/image_gallery.py
@@ -404,7 +404,7 @@ class ThumbnailMetaIcons(QLabel):
         self.icon_layout = HorizontalLayout(self)
         self.icon_layout.setAlignment(Qt.AlignLeft)
         self.icon_layout.setContentsMargins(0, 0, 0, 0)
-        self.setGeometry(9, img_size[0] - 11, 116, 20)
+        self.setGeometry(9, img_size[0] - 11, 130, 20)
 
         self.taxon_icon = FAIcon('mdi.bird', secondary=True, size=20)
         self.observation_icon = FAIcon('fa.binoculars', secondary=True, size=20)

--- a/naturtag/controllers/image_gallery.py
+++ b/naturtag/controllers/image_gallery.py
@@ -179,7 +179,7 @@ class ThumbnailCard(StylableWidget):
 
         self.context_menu = ThumbnailContextMenu(self)
         self.icons = ThumbnailMetaIcons(self)
-        self.icons.setObjectName('metadata-icons')
+        self.icons.setObjectName('metadata_icons')
 
         # Filename label
         text = re.sub('([_-])', '\\1\u200b', self.image_path.name)  # To allow word wrapping
@@ -288,7 +288,7 @@ class MetaThumbnail(HoverMixin, PixmapLabel):
 
     def __init__(self, parent: QWidget, size: Dimensions = SIZE_DEFAULT):
         # We will generate a thumbnail of final size; no scaling needed
-        super().__init__(parent, scale=False)
+        super().__init__(parent, rounded=True, scale=False)
         self.thumbnail_size = size
         self.setFixedSize(*size)
 

--- a/naturtag/controllers/observation_view.py
+++ b/naturtag/controllers/observation_view.py
@@ -130,7 +130,7 @@ class ObservationInfoSection(HorizontalLayout):
         # Load additional thumbnails
         self.thumbnails.clear()
         for i, photo in enumerate(obs.photos[1:11] if obs.photos else []):
-            thumb = ObservationPhoto(observation=obs, idx=i + 1)
+            thumb = ObservationPhoto(observation=obs, idx=i + 1, rounded=True)
             thumb.setFixedSize(*SIZE_SM)
             thumb.on_click.connect(self.image_window.display_observation_fullscreen)
             thumb.set_pixmap_async(self.threadpool, photo=photo, size='thumbnail')

--- a/naturtag/controllers/observation_view.py
+++ b/naturtag/controllers/observation_view.py
@@ -145,7 +145,7 @@ class ObservationInfoSection(HorizontalLayout):
         created_date_str = (
             obs.created_at.strftime('%Y-%m-%d %H:%M:%S') if obs.created_at else 'unknown date'
         )
-        num_ids = obs.identifications_count or len(obs.identifications)
+        num_ids = obs.identifications_count or 0
         quality_str = obs.quality_grade.replace('_', ' ').title().replace('Id', 'ID')
         self.description.setText(obs.description)
 

--- a/naturtag/controllers/observation_view.py
+++ b/naturtag/controllers/observation_view.py
@@ -48,7 +48,7 @@ class ObservationInfoSection(HorizontalLayout):
         self.addWidget(self.group_box)
 
         # Medium default photo
-        self.image = ObservationPhoto(hover_icon=True)
+        self.image = ObservationPhoto(hover_icon=True, hover_event=False)  # Disabled until 1st load
         self.image.setMaximumHeight(395)  # Height of 5 thumbnails + spacing
         self.image.setAlignment(Qt.AlignTop)
         images.addWidget(self.image)
@@ -119,6 +119,7 @@ class ObservationInfoSection(HorizontalLayout):
         self.history_taxon = None
         self.selected_observation = obs
         self.group_box.setTitle(obs.taxon.full_name)
+        self.image.hover_event = True
         self.image.observation = obs
         self.image.set_pixmap_async(
             self.threadpool,

--- a/naturtag/controllers/taxon_search.py
+++ b/naturtag/controllers/taxon_search.py
@@ -198,7 +198,9 @@ class RankList(HorizontalLayout):
 
         ranks = RANKS if all_ranks else COMMON_RANKS
         self.dropdown = QComboBox()
-        self.dropdown.addItems([''] + ranks[::-1])
+        # Workaround for miscalculated padding in pyqtdarktheme
+        #   (which appears to a add a check icon to the left, but doesn't account for its width)
+        self.dropdown.addItems([''] + [f'{r}   ' for r in ranks[::-1]])
         self.addWidget(self.dropdown)
 
     def reset(self):

--- a/naturtag/controllers/taxon_view.py
+++ b/naturtag/controllers/taxon_view.py
@@ -47,7 +47,7 @@ class TaxonInfoSection(HorizontalLayout):
         self.setAlignment(Qt.AlignTop)
 
         # Medium taxon default photo
-        self.image = TaxonPhoto(hover_icon=True)
+        self.image = TaxonPhoto(hover_icon=True, hover_event=False)  # Disabled until 1st load
         self.image.setFixedHeight(395)  # Height of 5 thumbnails + spacing
         self.image.setAlignment(Qt.AlignTop)
         images.addWidget(self.image)
@@ -109,6 +109,7 @@ class TaxonInfoSection(HorizontalLayout):
         self.history_taxon = None
         self.selected_taxon = taxon
         self.group_box.setTitle(taxon.full_name)
+        self.image.hover_event = True
         self.image.taxon = taxon
         self.image.set_pixmap_async(
             self.threadpool,

--- a/naturtag/controllers/taxon_view.py
+++ b/naturtag/controllers/taxon_view.py
@@ -120,7 +120,7 @@ class TaxonInfoSection(HorizontalLayout):
         # Load additional thumbnails
         self.thumbnails.clear()
         for i, photo in enumerate(taxon.taxon_photos[1:11] if taxon.taxon_photos else []):
-            thumb = TaxonPhoto(taxon=taxon, idx=i + 1)
+            thumb = TaxonPhoto(taxon=taxon, idx=i + 1, rounded=True)
             thumb.setFixedSize(*SIZE_SM)
             thumb.on_click.connect(self.image_window.display_taxon_fullscreen)
             thumb.set_pixmap_async(self.threadpool, photo=photo, size='thumbnail')

--- a/naturtag/widgets/images.py
+++ b/naturtag/widgets/images.py
@@ -333,6 +333,9 @@ class InfoCard(StylableWidget):
         self.title = QLabel()
         self.title.setTextFormat(Qt.RichText)
         self.title.setObjectName('h2')
+        # Don't let text steal mouse focus; pass click events to the card
+        self.title.mouseReleaseEvent = self.mouseReleaseEvent
+
         self.details_layout = VerticalLayout()
         self.details_layout.setAlignment(Qt.AlignLeft)
         self.details_layout.addWidget(self.title)

--- a/naturtag/widgets/images.py
+++ b/naturtag/widgets/images.py
@@ -321,7 +321,7 @@ class InfoCard(StylableWidget):
         # Details
         self.title = QLabel()
         self.title.setTextFormat(Qt.RichText)
-        self.title.setObjectName('h1')
+        self.title.setObjectName('h2')
         self.details_layout = VerticalLayout()
         self.details_layout.setAlignment(Qt.AlignLeft)
         self.details_layout.addWidget(self.title)

--- a/naturtag/widgets/images.py
+++ b/naturtag/widgets/images.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Iterator, Optional, TypeAlias
 
 from pyinaturalist import Photo
 from PySide6.QtCore import QSize, Qt, QThread, Signal
-from PySide6.QtGui import QFont, QIcon, QPainter, QPixmap
+from PySide6.QtGui import QBrush, QFont, QIcon, QPainter, QPixmap
 from PySide6.QtWidgets import QLabel, QScrollArea, QSizePolicy, QWidget
 
 from naturtag.app.style import fa_icon
@@ -110,6 +110,7 @@ class PixmapLabel(QLabel):
         url: str = None,
         description: str = None,
         resample: bool = True,
+        rounded: bool = False,
         scale: bool = True,
         idx: int = 0,
     ):
@@ -120,6 +121,7 @@ class PixmapLabel(QLabel):
         self.idx = idx
         self.path = None
         self.description = description
+        self.rounded = rounded
         self.scale = scale
         self.xform = Qt.SmoothTransformation if resample else Qt.FastTransformation
         if path or url:
@@ -184,14 +186,24 @@ class PixmapLabel(QLabel):
         super().mouseReleaseEvent(event)
 
     def paintEvent(self, event):
-        """Draw optional description text in the upper left corner of the image"""
+        """Optionally draw rounded corners and/or image description text"""
         super().paintEvent(event)
-        if not self.description:
-            return
+        if self.rounded:
+            self._draw_rounded_corners()
+        if self.description:
+            self._draw_description_text()
 
+    def _draw_rounded_corners(self):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, True)
+        brush = QBrush(self._pixmap)
+        painter.setBrush(brush)
+        painter.drawRoundedRect(self._pixmap.rect(), 6, 6)
+
+    def _draw_description_text(self):
+        painter = QPainter(self)
         font = QFont()
         font.setPixelSize(16)
-        painter = QPainter(self)
         painter.setFont(font)
 
         # Get text dimensions
@@ -201,7 +213,7 @@ class PixmapLabel(QLabel):
         text_width = painter.fontMetrics().horizontalAdvance(longest_line)
         text_height = metrics.height() * len(lines)
 
-        # Draw text with a a semitransparent background
+        # Draw text with a semitransparent background
         bg_color = self.palette().dark().color()
         bg_color.setAlpha(128)
         painter.fillRect(0, 0, text_width + 2, text_height + 2, bg_color)
@@ -228,13 +240,11 @@ class HoverMixin(MIXIN_BASE):
 
     Args:
         hover_icon: Add an 'open' icon on hover
-        disable_hover_event: Don't automatically show overlay on hover
+        hover_event: Set to ``False`` to disable overlay on hover
             (e.g., to use parent widget hover event instead)
     """
 
-    def __init__(
-        self, *args, hover_icon: bool = False, disable_hover_event: bool = False, **kwargs
-    ):
+    def __init__(self, *args, hover_icon: bool = False, hover_event: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self.overlay = FAIcon('mdi.open-in-new', self, size=64) if hover_icon else QLabel(self)
         self.overlay.setAlignment(Qt.AlignTop)
@@ -242,19 +252,19 @@ class HoverMixin(MIXIN_BASE):
         self.overlay.setGeometry(self.geometry())
         self.overlay.setObjectName('hover_overlay')
         self.overlay.setVisible(False)
-        self.disable_hover_event = disable_hover_event
+        self.hover_event = hover_event
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self.overlay.setFixedSize(self.size())
 
     def enterEvent(self, event):
-        if not self.disable_hover_event:
+        if self.hover_event:
             self.overlay.setVisible(True)
         super().enterEvent(event)
 
     def leaveEvent(self, event):
-        if not self.disable_hover_event:
+        if self.hover_event:
             self.overlay.setVisible(False)
         super().leaveEvent(event)
 
@@ -314,8 +324,9 @@ class InfoCard(StylableWidget):
         self.card_id = card_id
 
         # Image
-        self.thumbnail = HoverPhoto(disable_hover_event=True)  # Use card hover event instead
+        self.thumbnail = HoverPhoto(rounded=True, hover_event=False)  # Use card hover event
         self.thumbnail.setFixedSize(*SIZE_SM)
+        self.thumbnail.setObjectName('thumbnail')
         card_layout.addWidget(self.thumbnail)
 
         # Details

--- a/naturtag/widgets/images.py
+++ b/naturtag/widgets/images.py
@@ -3,12 +3,12 @@ Includes plain images, cards, scrollable lists, and fullscreen image views.
 """
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, Optional, TypeAlias
+from typing import TYPE_CHECKING, Iterator, Optional, TypeAlias, Union
 
 from pyinaturalist import Photo
 from PySide6.QtCore import QSize, Qt, QThread, Signal
 from PySide6.QtGui import QBrush, QFont, QIcon, QPainter, QPixmap
-from PySide6.QtWidgets import QLabel, QScrollArea, QSizePolicy, QWidget
+from PySide6.QtWidgets import QLabel, QLayout, QScrollArea, QSizePolicy, QWidget
 
 from naturtag.app.style import fa_icon
 from naturtag.client import IMG_SESSION
@@ -338,9 +338,12 @@ class InfoCard(StylableWidget):
         self.details_layout.addWidget(self.title)
         card_layout.addLayout(self.details_layout)
 
-    def add_line(self, widget: QWidget):
-        """Add a widget as a line of info to the card"""
-        self.details_layout.addWidget(widget)
+    def add_row(self, item: Union[QLayout, QWidget]):
+        """Add a layout or widget as a row of info to the card"""
+        if isinstance(item, QLayout):
+            self.details_layout.addLayout(item)
+        else:
+            self.details_layout.addWidget(item)
 
     def enterEvent(self, event):
         """Note on hover effect:

--- a/naturtag/widgets/observation_images.py
+++ b/naturtag/widgets/observation_images.py
@@ -1,7 +1,7 @@
 """Image widgets specifically for observation photos"""
 from logging import getLogger
 from string import capwords
-from typing import TYPE_CHECKING, Iterable, Optional
+from typing import Iterable, Optional
 
 from pyinaturalist import Observation, Photo
 from PySide6.QtCore import Qt
@@ -155,8 +155,8 @@ class ObservationImageWindow(ImageWindow):
         """Open window to a selected observation image, and save other image URLs for navigation"""
         idx = observation_photo.idx
         obs = observation_photo.observation
-        if TYPE_CHECKING:
-            assert obs is not None
+        if not obs:
+            return
 
         self.observation = obs
         self.selected_photo = obs.photos[idx] if obs.photos else Photo()  # TODO

--- a/naturtag/widgets/observation_images.py
+++ b/naturtag/widgets/observation_images.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Iterable, Optional
 from pyinaturalist import Observation, Photo
 from PySide6.QtCore import Qt
 
+from naturtag.constants import SIZE_ICON_SM
 from naturtag.widgets.images import HoverPhoto, IconLabel, ImageWindow, InfoCard, InfoCardList
 from naturtag.widgets.layouts import HorizontalLayout
 
@@ -57,16 +58,17 @@ class ObservationInfoCard(InfoCard):
         date_str = obs.observed_on.strftime('%Y-%m-%d') if obs.observed_on else 'unknown date'
         num_ids = obs.identifications_count or 0
         num_photos = len(obs.photos)
+        icon_size = SIZE_ICON_SM[0]
         layout = HorizontalLayout()
         layout.setSpacing(0)
         layout.setAlignment(Qt.AlignLeft)
-        layout.addWidget(IconLabel('fa5.calendar-alt', date_str, size=20))
-        layout.addWidget(IconLabel('mdi.marker-check', num_ids, size=20))
+        layout.addWidget(IconLabel('fa5.calendar-alt', date_str, size=icon_size))
+        layout.addWidget(IconLabel('mdi.marker-check', num_ids, size=icon_size))
         layout.addWidget(
             IconLabel(
                 'fa5.images' if num_photos > 1 else 'fa5.image',
                 num_photos,
-                size=20,
+                size=icon_size,
             )
         )
         if obs.sounds:
@@ -74,20 +76,18 @@ class ObservationInfoCard(InfoCard):
                 IconLabel(
                     'ri.volume-up-fill',
                     len(obs.sounds),
-                    size=20,
+                    size=icon_size,
                 )
             )
         layout.addWidget(
             IconLabel(
                 QUALITY_GRADE_ICONS.get(obs.quality_grade, 'mdi.chevron-up'),
                 obs.quality_grade.replace('_', ' ').title(),
-                size=20,
+                size=icon_size,
             )
         )
-        self.details_layout.addLayout(layout)
-        self.details_layout.addWidget(
-            IconLabel('fa.map-marker', obs.place_guess or obs.location, size=20)
-        )
+        self.add_row(layout)
+        self.add_row(IconLabel('fa.map-marker', obs.place_guess or obs.location, size=icon_size))
 
         # Add more verbose details in tooltip
         tooltip_lines = [

--- a/naturtag/widgets/observation_images.py
+++ b/naturtag/widgets/observation_images.py
@@ -55,7 +55,7 @@ class ObservationInfoCard(InfoCard):
 
         # Details: Date, place guess, number of ids and photos, quality grade
         date_str = obs.observed_on.strftime('%Y-%m-%d') if obs.observed_on else 'unknown date'
-        num_ids = obs.identifications_count or len(obs.identifications)
+        num_ids = obs.identifications_count or 0
         num_photos = len(obs.photos)
         layout = HorizontalLayout()
         layout.setSpacing(0)

--- a/naturtag/widgets/taxon_images.py
+++ b/naturtag/widgets/taxon_images.py
@@ -112,8 +112,8 @@ class TaxonImageWindow(ImageWindow):
         """Open window to a selected taxon image, and save other image URLs for navigation"""
         idx = taxon_photo.idx
         taxon = taxon_photo.taxon
-        if TYPE_CHECKING:
-            assert taxon is not None
+        if not taxon:
+            return
 
         self.taxon = taxon
         self.selected_photo = taxon.taxon_photos[idx] if taxon.taxon_photos else taxon.default_photo

--- a/naturtag/widgets/taxon_images.py
+++ b/naturtag/widgets/taxon_images.py
@@ -1,6 +1,7 @@
 """Image widgets specifically for taxon photos"""
 import re
 from logging import getLogger
+from string import capwords
 from typing import TYPE_CHECKING, Iterable, Optional
 
 from pyinaturalist import Photo, Taxon
@@ -46,7 +47,7 @@ class TaxonInfoCard(InfoCard):
 
         # Details
         self.title.setText(f'{taxon.rank.title()}: <i>{taxon.name}</i>')
-        self.add_line(QLabel((taxon.preferred_common_name or '').title()))
+        self.add_line(QLabel(capwords(taxon.preferred_common_name or '')))
         layout = HorizontalLayout()
         layout.setSpacing(0)
         layout.setAlignment(Qt.AlignLeft)

--- a/naturtag/widgets/taxon_images.py
+++ b/naturtag/widgets/taxon_images.py
@@ -8,6 +8,7 @@ from pyinaturalist import Photo, Taxon
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QLabel
 
+from naturtag.constants import SIZE_ICON_SM
 from naturtag.widgets import (
     HorizontalLayout,
     HoverPhoto,
@@ -47,16 +48,17 @@ class TaxonInfoCard(InfoCard):
 
         # Details
         self.title.setText(f'{taxon.rank.title()}: <i>{taxon.name}</i>')
-        self.add_line(QLabel(capwords(taxon.preferred_common_name or '')))
+        self.add_row(QLabel(capwords(taxon.preferred_common_name or '')))
+        icon_size = SIZE_ICON_SM[0]
         layout = HorizontalLayout()
         layout.setSpacing(0)
         layout.setAlignment(Qt.AlignLeft)
-        layout.addWidget(IconLabel('fa.binoculars', taxon.observations_count or 0, size=20))
+        layout.addWidget(IconLabel('fa.binoculars', taxon.observations_count or 0, size=icon_size))
         if taxon.complete_species_count:
-            layout.addWidget(IconLabel('mdi.leaf', taxon.complete_species_count, size=20))
+            layout.addWidget(IconLabel('mdi.leaf', taxon.complete_species_count, size=icon_size))
         if user_observations_count:
-            layout.addWidget(IconLabel('fa5s.user', user_observations_count, size=20))
-        self.details_layout.addLayout(layout)
+            layout.addWidget(IconLabel('fa5s.user', user_observations_count, size=icon_size))
+        self.add_row(layout)
 
 
 class TaxonList(InfoCardList):

--- a/poetry.lock
+++ b/poetry.lock
@@ -235,7 +235,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0rc9"
+version = "1.0.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
@@ -302,18 +302,19 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "greenlet"
-version = "1.1.3.post0"
+version = "2.0.0"
 description = "Lightweight in-process concurrent programming"
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
-docs = ["Sphinx"]
+docs = ["Sphinx", "docutils (<0.18)"]
+test = ["faulthandler", "objgraph"]
 
 [[package]]
 name = "identify"
-version = "2.5.7"
+version = "2.5.8"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -591,7 +592,7 @@ future = "*"
 
 [[package]]
 name = "Pillow"
-version = "9.2.0"
+version = "9.3.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
 optional = false
@@ -671,7 +672,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyexiv2"
-version = "2.8.0"
+version = "2.8.1"
 description = "Read/Write metadata(including EXIF, IPTC, XMP), comment and ICC Profile embedded in digital images."
 category = "main"
 optional = false
@@ -739,7 +740,7 @@ xlsx = ["openpyxl (>=2.6)", "pandas (>=1.2)"]
 
 [[package]]
 name = "pyinstaller"
-version = "5.6.1"
+version = "5.6.2"
 description = "PyInstaller bundles a Python application and all its dependencies into a single package."
 category = "dev"
 optional = false
@@ -759,7 +760,7 @@ hook_testing = ["execnet (>=1.5.0)", "psutil", "pytest (>=2.7.3)"]
 
 [[package]]
 name = "pyinstaller-hooks-contrib"
-version = "2022.10"
+version = "2022.11"
 description = "Community maintained hooks for PyInstaller"
 category = "dev"
 optional = false
@@ -775,6 +776,14 @@ python-versions = ">=3.6.8"
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pyqtdarktheme"
+version = "1.1.1"
+description = "Flat dark theme for PySide and PyQt."
+category = "main"
+optional = false
+python-versions = ">=3.7,<3.12"
 
 [[package]]
 name = "pyrate-limiter"
@@ -902,7 +911,7 @@ testing = ["coverage", "mypy", "pylint", "pytest"]
 
 [[package]]
 name = "pytz"
-version = "2022.5"
+version = "2022.6"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = true
@@ -934,17 +943,6 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 qtpy = "*"
-
-[[package]]
-name = "qtmodern"
-version = "0.2.0"
-description = "Qt Widgets Modern User Interface"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-qtpy = ">=1.3.1"
 
 [[package]]
 name = "QtPy"
@@ -1339,11 +1337,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tomlkit"
-version = "0.11.5"
+version = "0.11.6"
 description = "Style preserving TOML library"
 category = "dev"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.6"
 
 [[package]]
 name = "typing-extensions"
@@ -1412,7 +1410,7 @@ docs = ["furo", "linkify-it-py", "myst-parser", "sphinx", "sphinx-autodoc-typehi
 [metadata]
 lock-version = "1.1"
 python-versions = '>=3.10,<3.11'
-content-hash = "023ae7100d6b3880a5dc08842f05f62bcfe326a1e5f574829f206208bcdeddae"
+content-hash = "36251b54d591ddfd39f903de13ba70b360ba108022e8f82aaccc76dac46d8eed"
 
 [metadata.files]
 alabaster = [
@@ -1634,8 +1632,8 @@ docutils = [
     {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
-    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
+    {file = "exceptiongroup-1.0.0-py3-none-any.whl", hash = "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41"},
+    {file = "exceptiongroup-1.0.0.tar.gz", hash = "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"},
 ]
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
@@ -1657,76 +1655,65 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 greenlet = [
-    {file = "greenlet-1.1.3.post0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:949c9061b8c6d3e6e439466a9be1e787208dec6246f4ec5fffe9677b4c19fcc3"},
-    {file = "greenlet-1.1.3.post0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:d7815e1519a8361c5ea2a7a5864945906f8e386fa1bc26797b4d443ab11a4589"},
-    {file = "greenlet-1.1.3.post0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9649891ab4153f217f319914455ccf0b86986b55fc0573ce803eb998ad7d6854"},
-    {file = "greenlet-1.1.3.post0-cp27-cp27m-win32.whl", hash = "sha256:11fc7692d95cc7a6a8447bb160d98671ab291e0a8ea90572d582d57361360f05"},
-    {file = "greenlet-1.1.3.post0-cp27-cp27m-win_amd64.whl", hash = "sha256:05ae7383f968bba4211b1fbfc90158f8e3da86804878442b4fb6c16ccbcaa519"},
-    {file = "greenlet-1.1.3.post0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ccbe7129a282ec5797df0451ca1802f11578be018a32979131065565da89b392"},
-    {file = "greenlet-1.1.3.post0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a8b58232f5b72973350c2b917ea3df0bebd07c3c82a0a0e34775fc2c1f857e9"},
-    {file = "greenlet-1.1.3.post0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:f6661b58412879a2aa099abb26d3c93e91dedaba55a6394d1fb1512a77e85de9"},
-    {file = "greenlet-1.1.3.post0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c6e942ca9835c0b97814d14f78da453241837419e0d26f7403058e8db3e38f8"},
-    {file = "greenlet-1.1.3.post0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a812df7282a8fc717eafd487fccc5ba40ea83bb5b13eb3c90c446d88dbdfd2be"},
-    {file = "greenlet-1.1.3.post0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83a7a6560df073ec9de2b7cb685b199dfd12519bc0020c62db9d1bb522f989fa"},
-    {file = "greenlet-1.1.3.post0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:17a69967561269b691747e7f436d75a4def47e5efcbc3c573180fc828e176d80"},
-    {file = "greenlet-1.1.3.post0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:60839ab4ea7de6139a3be35b77e22e0398c270020050458b3d25db4c7c394df5"},
-    {file = "greenlet-1.1.3.post0-cp310-cp310-win_amd64.whl", hash = "sha256:8926a78192b8b73c936f3e87929931455a6a6c6c385448a07b9f7d1072c19ff3"},
-    {file = "greenlet-1.1.3.post0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c6f90234e4438062d6d09f7d667f79edcc7c5e354ba3a145ff98176f974b8132"},
-    {file = "greenlet-1.1.3.post0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:814f26b864ed2230d3a7efe0336f5766ad012f94aad6ba43a7c54ca88dd77cba"},
-    {file = "greenlet-1.1.3.post0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8fda1139d87ce5f7bd80e80e54f9f2c6fe2f47983f1a6f128c47bf310197deb6"},
-    {file = "greenlet-1.1.3.post0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0643250dd0756f4960633f5359884f609a234d4066686754e834073d84e9b51"},
-    {file = "greenlet-1.1.3.post0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:cb863057bed786f6622982fb8b2c122c68e6e9eddccaa9fa98fd937e45ee6c4f"},
-    {file = "greenlet-1.1.3.post0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8c0581077cf2734569f3e500fab09c0ff6a2ab99b1afcacbad09b3c2843ae743"},
-    {file = "greenlet-1.1.3.post0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:695d0d8b5ae42c800f1763c9fce9d7b94ae3b878919379150ee5ba458a460d57"},
-    {file = "greenlet-1.1.3.post0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:5662492df0588a51d5690f6578f3bbbd803e7f8d99a99f3bf6128a401be9c269"},
-    {file = "greenlet-1.1.3.post0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:bffba15cff4802ff493d6edcf20d7f94ab1c2aee7cfc1e1c7627c05f1102eee8"},
-    {file = "greenlet-1.1.3.post0-cp35-cp35m-win32.whl", hash = "sha256:7afa706510ab079fd6d039cc6e369d4535a48e202d042c32e2097f030a16450f"},
-    {file = "greenlet-1.1.3.post0-cp35-cp35m-win_amd64.whl", hash = "sha256:3a24f3213579dc8459e485e333330a921f579543a5214dbc935bc0763474ece3"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:64e10f303ea354500c927da5b59c3802196a07468332d292aef9ddaca08d03dd"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:eb6ac495dccb1520667cfea50d89e26f9ffb49fa28496dea2b95720d8b45eb54"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:88720794390002b0c8fa29e9602b395093a9a766b229a847e8d88349e418b28a"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39464518a2abe9c505a727af7c0b4efff2cf242aa168be5f0daa47649f4d7ca8"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0914f02fcaa8f84f13b2df4a81645d9e82de21ed95633765dd5cc4d3af9d7403"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96656c5f7c95fc02c36d4f6ef32f4e94bb0b6b36e6a002c21c39785a4eec5f5d"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:4f74aa0092602da2069df0bc6553919a15169d77bcdab52a21f8c5242898f519"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:3aeac044c324c1a4027dca0cde550bd83a0c0fbff7ef2c98df9e718a5086c194"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-win32.whl", hash = "sha256:fe7c51f8a2ab616cb34bc33d810c887e89117771028e1e3d3b77ca25ddeace04"},
-    {file = "greenlet-1.1.3.post0-cp36-cp36m-win_amd64.whl", hash = "sha256:70048d7b2c07c5eadf8393e6398595591df5f59a2f26abc2f81abca09610492f"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:66aa4e9a726b70bcbfcc446b7ba89c8cec40f405e51422c39f42dfa206a96a05"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:025b8de2273d2809f027d347aa2541651d2e15d593bbce0d5f502ca438c54136"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:82a38d7d2077128a017094aff334e67e26194f46bd709f9dcdacbf3835d47ef5"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7d20c3267385236b4ce54575cc8e9f43e7673fc761b069c820097092e318e3b"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c8ece5d1a99a2adcb38f69af2f07d96fb615415d32820108cd340361f590d128"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2794eef1b04b5ba8948c72cc606aab62ac4b0c538b14806d9c0d88afd0576d6b"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a8d24eb5cb67996fb84633fdc96dbc04f2d8b12bfcb20ab3222d6be271616b67"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:0120a879aa2b1ac5118bce959ea2492ba18783f65ea15821680a256dfad04754"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-win32.whl", hash = "sha256:bef49c07fcb411c942da6ee7d7ea37430f830c482bf6e4b72d92fd506dd3a427"},
-    {file = "greenlet-1.1.3.post0-cp37-cp37m-win_amd64.whl", hash = "sha256:62723e7eb85fa52e536e516ee2ac91433c7bb60d51099293671815ff49ed1c21"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d25cdedd72aa2271b984af54294e9527306966ec18963fd032cc851a725ddc1b"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:924df1e7e5db27d19b1359dc7d052a917529c95ba5b8b62f4af611176da7c8ad"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ec615d2912b9ad807afd3be80bf32711c0ff9c2b00aa004a45fd5d5dde7853d9"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0971d37ae0eaf42344e8610d340aa0ad3d06cd2eee381891a10fe771879791f9"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325f272eb997916b4a3fc1fea7313a8adb760934c2140ce13a2117e1b0a8095d"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d75afcbb214d429dacdf75e03a1d6d6c5bd1fa9c35e360df8ea5b6270fb2211c"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5c2d21c2b768d8c86ad935e404cc78c30d53dea009609c3ef3a9d49970c864b5"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:467b73ce5dcd89e381292fb4314aede9b12906c18fab903f995b86034d96d5c8"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-win32.whl", hash = "sha256:8149a6865b14c33be7ae760bcdb73548bb01e8e47ae15e013bf7ef9290ca309a"},
-    {file = "greenlet-1.1.3.post0-cp38-cp38-win_amd64.whl", hash = "sha256:104f29dd822be678ef6b16bf0035dcd43206a8a48668a6cae4d2fe9c7a7abdeb"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:c8c9301e3274276d3d20ab6335aa7c5d9e5da2009cccb01127bddb5c951f8870"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:8415239c68b2ec9de10a5adf1130ee9cb0ebd3e19573c55ba160ff0ca809e012"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:3c22998bfef3fcc1b15694818fc9b1b87c6cc8398198b96b6d355a7bcb8c934e"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0aa1845944e62f358d63fcc911ad3b415f585612946b8edc824825929b40e59e"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:890f633dc8cb307761ec566bc0b4e350a93ddd77dc172839be122be12bae3e10"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cf37343e43404699d58808e51f347f57efd3010cc7cee134cdb9141bd1ad9ea"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5edf75e7fcfa9725064ae0d8407c849456553a181ebefedb7606bac19aa1478b"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0a954002064ee919b444b19c1185e8cce307a1f20600f47d6f4b6d336972c809"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-win32.whl", hash = "sha256:2ccdc818cc106cc238ff7eba0d71b9c77be868fdca31d6c3b1347a54c9b187b2"},
-    {file = "greenlet-1.1.3.post0-cp39-cp39-win_amd64.whl", hash = "sha256:91a84faf718e6f8b888ca63d0b2d6d185c8e2a198d2a7322d75c303e7097c8b7"},
-    {file = "greenlet-1.1.3.post0.tar.gz", hash = "sha256:f5e09dc5c6e1796969fd4b775ea1417d70e49a5df29aaa8e5d10675d9e11872c"},
+    {file = "greenlet-2.0.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:4be4dedbd2fa9b7c35627f322d6d3139cb125bc18d5ef2f40237990850ea446f"},
+    {file = "greenlet-2.0.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:75c022803de010294366f3608d4bba3e346693b1b7427b79d57e3d924ed03838"},
+    {file = "greenlet-2.0.0-cp27-cp27m-win32.whl", hash = "sha256:4a1953465b7651073cffde74ed7d121e602ef9a9740d09ee137b01879ac15a2f"},
+    {file = "greenlet-2.0.0-cp27-cp27m-win_amd64.whl", hash = "sha256:a65205e6778142528978b4acca76888e7e7f0be261e395664e49a5c21baa2141"},
+    {file = "greenlet-2.0.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d71feebf5c8041c80dfda76427e14e3ca00bca042481bd3e9612a9d57b2cbbf7"},
+    {file = "greenlet-2.0.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:f7edbd2957f72aea357241fe42ffc712a8e9b8c2c42f24e2ef5d97b255f66172"},
+    {file = "greenlet-2.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79687c48e7f564be40c46b3afea6d141b8d66ffc2bc6147e026d491c6827954a"},
+    {file = "greenlet-2.0.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a245898ec5e9ca0bc87a63e4e222cc633dc4d1f1a0769c34a625ad67edb9f9de"},
+    {file = "greenlet-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:adcf45221f253b3a681c99da46fa6ac33596fa94c2f30c54368f7ee1c4563a39"},
+    {file = "greenlet-2.0.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3dc294afebf2acfd029373dbf3d01d36fd8d6888a03f5a006e2d690f66b153d9"},
+    {file = "greenlet-2.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1cfeae4dda32eb5c64df05d347c4496abfa57ad16a90082798a2bba143c6c854"},
+    {file = "greenlet-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:d58d4b4dc82e2d21ebb7dd7d3a6d370693b2236a1407fe3988dc1d4ea07575f9"},
+    {file = "greenlet-2.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e0d7efab8418c1fb3ea00c4abb89e7b0179a952d0d53ad5fcff798ca7440f8e8"},
+    {file = "greenlet-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:f8a10e14238407be3978fa6d190eb3724f9d766655fefc0134fd5482f1fb0108"},
+    {file = "greenlet-2.0.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:98b848a0b75e76b446dc71fdbac712d9078d96bb1c1607f049562dde1f8801e1"},
+    {file = "greenlet-2.0.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:8e8dbad9b4f4c3e37898914cfccb7c4f00dbe3146333cfe52a1a3103cc2ff97c"},
+    {file = "greenlet-2.0.0-cp35-cp35m-win32.whl", hash = "sha256:069a8a557541a04518dc3beb9a78637e4e6b286814849a2ecfac529eaa78562b"},
+    {file = "greenlet-2.0.0-cp35-cp35m-win_amd64.whl", hash = "sha256:cc211c2ff5d3b2ba8d557a71e3b4f0f0a2020067515143a9516ea43884271192"},
+    {file = "greenlet-2.0.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:d4e7642366e638f45d70c5111590a56fbd0ffb7f474af20c6c67c01270bcf5cf"},
+    {file = "greenlet-2.0.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e7a0dca752b4e3395890ab4085c3ec3838d73714261914c01b53ed7ea23b5867"},
+    {file = "greenlet-2.0.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8c67ecda450ad4eac7837057f5deb96effa836dacaf04747710ccf8eeb73092"},
+    {file = "greenlet-2.0.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3cc1abaf47cfcfdc9ac0bdff173cebab22cd54e9e3490135a4a9302d0ff3b163"},
+    {file = "greenlet-2.0.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efdbbbf7b6c8d5be52977afa65b9bb7b658bab570543280e76c0fabc647175ed"},
+    {file = "greenlet-2.0.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:7acaa51355d5b9549d474dc71be6846ee9a8f2cb82f4936e5efa7a50bbeb94ad"},
+    {file = "greenlet-2.0.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:2be628bca0395610da08921f9376dd14317f37256d41078f5c618358467681e1"},
+    {file = "greenlet-2.0.0-cp36-cp36m-win32.whl", hash = "sha256:eca9c0473de053dcc92156dd62c38c3578628b536c7f0cd66e655e211c14ac32"},
+    {file = "greenlet-2.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:9a4a9fea68fd98814999d91ea585e49ed68d7e199a70bef13a857439f60a4609"},
+    {file = "greenlet-2.0.0-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:6b28420ae290bfbf5d827f976abccc2f74f0a3f5e4fb69b66acf98f1cbe95e7e"},
+    {file = "greenlet-2.0.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2b8e1c939b363292ecc93999fb1ad53ffc5d0aac8e933e4362b62365241edda5"},
+    {file = "greenlet-2.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c5ddadfe40e903c6217ed2b95a79f49e942bb98527547cc339fc7e43a424aad"},
+    {file = "greenlet-2.0.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e5ead803b11b60b347e08e0f37234d9a595f44a6420026e47bcaf94190c3cd6"},
+    {file = "greenlet-2.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b89b78ffb516c2921aa180c2794082666e26680eef05996b91f46127da24d964"},
+    {file = "greenlet-2.0.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:939963d0137ec92540d95b68b7f795e8dbadce0a1fca53e3e7ef8ddc18ee47cb"},
+    {file = "greenlet-2.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c1e93ef863810fba75faf418f0861dbf59bfe01a7b5d0a91d39603df58d3d3fa"},
+    {file = "greenlet-2.0.0-cp37-cp37m-win32.whl", hash = "sha256:6fd342126d825b76bf5b49717a7c682e31ed1114906cdec7f5a0c2ff1bc737a7"},
+    {file = "greenlet-2.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5392ddb893e7fba237b988f846c4a80576557cc08664d56dc1a69c5c02bdc80c"},
+    {file = "greenlet-2.0.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b4fd73b62c1038e7ee938b1de328eaa918f76aa69c812beda3aff8a165494201"},
+    {file = "greenlet-2.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:0ba0f2e5c4a8f141952411e356dba05d6fe0c38325ee0e4f2d0c6f4c2c3263d5"},
+    {file = "greenlet-2.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8bacecee0c9348ab7c95df810e12585e9e8c331dfc1e22da4ed0bd635a5f483"},
+    {file = "greenlet-2.0.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:341053e0a96d512315c27c34fad4672c4573caf9eb98310c39e7747645c88d8b"},
+    {file = "greenlet-2.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49fcdd8ae391ffabb3b672397b58a9737aaff6b8cae0836e8db8ff386fcea802"},
+    {file = "greenlet-2.0.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c3aa7d3bc545162a6676445709b24a2a375284dc5e2f2432d58b80827c2bd91c"},
+    {file = "greenlet-2.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9d8dca31a39dd9f25641559b8cdf9066168c682dfcfbe0f797f03e4c9718a63a"},
+    {file = "greenlet-2.0.0-cp38-cp38-win32.whl", hash = "sha256:aa2b371c3633e694d043d6cec7376cb0031c6f67029f37eef40bda105fd58753"},
+    {file = "greenlet-2.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:0fa2a66fdf0d09929e79f786ad61529d4e752f452466f7ddaa5d03caf77a603d"},
+    {file = "greenlet-2.0.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:e7ec3f2465ba9b7d25895307abe1c1c101a257c54b9ea1522bbcbe8ca8793735"},
+    {file = "greenlet-2.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:99e9851e40150504474915605649edcde259a4cd9bce2fcdeb4cf33ad0b5c293"},
+    {file = "greenlet-2.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20bf68672ae14ef2e2e6d3ac1f308834db1d0b920b3b0674eef48b2dce0498dd"},
+    {file = "greenlet-2.0.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30198bccd774f9b6b1ba7564a0d02a79dd1fe926cfeb4107856fe16c9dfb441c"},
+    {file = "greenlet-2.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d65d7d1ff64fb300127d2ffd27db909de4d21712a5dde59a3ad241fb65ee83d7"},
+    {file = "greenlet-2.0.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2f5d396a5457458460b0c28f738fc8ab2738ee61b00c3f845c7047a333acd96c"},
+    {file = "greenlet-2.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:09f00f9938eb5ae1fe203558b56081feb0ca34a2895f8374cd01129ddf4d111c"},
+    {file = "greenlet-2.0.0-cp39-cp39-win32.whl", hash = "sha256:089e123d80dbc6f61fff1ff0eae547b02c343d50968832716a7b0a33bea5f792"},
+    {file = "greenlet-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc283f99a4815ef70cad537110e3e03abcef56ab7d005ba9a8c6ec33054ce9c0"},
+    {file = "greenlet-2.0.0.tar.gz", hash = "sha256:6c66f0da8049ee3c126b762768179820d4c0ae0ca46ae489039e4da2fae39a52"},
 ]
 identify = [
-    {file = "identify-2.5.7-py2.py3-none-any.whl", hash = "sha256:7a67b2a6208d390fd86fd04fb3def94a3a8b7f0bcbd1d1fcd6736f4defe26390"},
-    {file = "identify-2.5.7.tar.gz", hash = "sha256:5b8fd1e843a6d4bf10685dd31f4520a7f1c7d0e14e9bc5d34b1d6f111cabc011"},
+    {file = "identify-2.5.8-py2.py3-none-any.whl", hash = "sha256:48b7925fe122720088aeb7a6c34f17b27e706b72c61070f27fe3789094233440"},
+    {file = "identify-2.5.8.tar.gz", hash = "sha256:7a214a10313b9489a0d61467db2856ae8d0b8306fc923e03a9effa53d8aedc58"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -1850,64 +1837,65 @@ pefile = [
     {file = "pefile-2022.5.30.tar.gz", hash = "sha256:a5488a3dd1fd021ce33f969780b88fe0f7eebb76eb20996d7318f307612a045b"},
 ]
 Pillow = [
-    {file = "Pillow-9.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a9c9bc489f8ab30906d7a85afac4b4944a572a7432e00698a7239f44a44e6efb"},
-    {file = "Pillow-9.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:510cef4a3f401c246cfd8227b300828715dd055463cdca6176c2e4036df8bd4f"},
-    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7888310f6214f19ab2b6df90f3f06afa3df7ef7355fc025e78a3044737fab1f5"},
-    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:831e648102c82f152e14c1a0938689dbb22480c548c8d4b8b248b3e50967b88c"},
-    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cc1d2451e8a3b4bfdb9caf745b58e6c7a77d2e469159b0d527a4554d73694d1"},
-    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:136659638f61a251e8ed3b331fc6ccd124590eeff539de57c5f80ef3a9594e58"},
-    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6e8c66f70fb539301e064f6478d7453e820d8a2c631da948a23384865cd95544"},
-    {file = "Pillow-9.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e"},
-    {file = "Pillow-9.2.0-cp310-cp310-win32.whl", hash = "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28"},
-    {file = "Pillow-9.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437"},
-    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004"},
-    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0"},
-    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4"},
-    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:15928f824870535c85dbf949c09d6ae7d3d6ac2d6efec80f3227f73eefba741c"},
-    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:bdd0de2d64688ecae88dd8935012c4a72681e5df632af903a1dca8c5e7aa871a"},
-    {file = "Pillow-9.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d5b87da55a08acb586bad5c3aa3b86505f559b84f39035b233d5bf844b0834b1"},
-    {file = "Pillow-9.2.0-cp311-cp311-win32.whl", hash = "sha256:b6d5e92df2b77665e07ddb2e4dbd6d644b78e4c0d2e9272a852627cdba0d75cf"},
-    {file = "Pillow-9.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6bf088c1ce160f50ea40764f825ec9b72ed9da25346216b91361eef8ad1b8f8c"},
-    {file = "Pillow-9.2.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:2c58b24e3a63efd22554c676d81b0e57f80e0a7d3a5874a7e14ce90ec40d3069"},
-    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef7592281f7c174d3d6cbfbb7ee5984a671fcd77e3fc78e973d492e9bf0eb3f"},
-    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcd7b9c7139dc8258d164b55696ecd16c04607f1cc33ba7af86613881ffe4ac8"},
-    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a138441e95562b3c078746a22f8fca8ff1c22c014f856278bdbdd89ca36cff1b"},
-    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:93689632949aff41199090eff5474f3990b6823404e45d66a5d44304e9cdc467"},
-    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:f3fac744f9b540148fa7715a435d2283b71f68bfb6d4aae24482a890aed18b59"},
-    {file = "Pillow-9.2.0-cp37-cp37m-win32.whl", hash = "sha256:fa768eff5f9f958270b081bb33581b4b569faabf8774726b283edb06617101dc"},
-    {file = "Pillow-9.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:69bd1a15d7ba3694631e00df8de65a8cb031911ca11f44929c97fe05eb9b6c1d"},
-    {file = "Pillow-9.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:030e3460861488e249731c3e7ab59b07c7853838ff3b8e16aac9561bb345da14"},
-    {file = "Pillow-9.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:74a04183e6e64930b667d321524e3c5361094bb4af9083db5c301db64cd341f3"},
-    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d33a11f601213dcd5718109c09a52c2a1c893e7461f0be2d6febc2879ec2402"},
-    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fd6f5e3c0e4697fa7eb45b6e93996299f3feee73a3175fa451f49a74d092b9f"},
-    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a647c0d4478b995c5e54615a2e5360ccedd2f85e70ab57fbe817ca613d5e63b8"},
-    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:4134d3f1ba5f15027ff5c04296f13328fecd46921424084516bdb1b2548e66ff"},
-    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:bc431b065722a5ad1dfb4df354fb9333b7a582a5ee39a90e6ffff688d72f27a1"},
-    {file = "Pillow-9.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:1536ad017a9f789430fb6b8be8bf99d2f214c76502becc196c6f2d9a75b01b76"},
-    {file = "Pillow-9.2.0-cp38-cp38-win32.whl", hash = "sha256:2ad0d4df0f5ef2247e27fc790d5c9b5a0af8ade9ba340db4a73bb1a4a3e5fb4f"},
-    {file = "Pillow-9.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:ec52c351b35ca269cb1f8069d610fc45c5bd38c3e91f9ab4cbbf0aebc136d9c8"},
-    {file = "Pillow-9.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0ed2c4ef2451de908c90436d6e8092e13a43992f1860275b4d8082667fbb2ffc"},
-    {file = "Pillow-9.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ad2f835e0ad81d1689f1b7e3fbac7b01bb8777d5a985c8962bedee0cc6d43da"},
-    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea98f633d45f7e815db648fd7ff0f19e328302ac36427343e4432c84432e7ff4"},
-    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7761afe0126d046974a01e030ae7529ed0ca6a196de3ec6937c11df0df1bc91c"},
-    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a54614049a18a2d6fe156e68e188da02a046a4a93cf24f373bffd977e943421"},
-    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:5aed7dde98403cd91d86a1115c78d8145c83078e864c1de1064f52e6feb61b20"},
-    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:13b725463f32df1bfeacbf3dd197fb358ae8ebcd8c5548faa75126ea425ccb60"},
-    {file = "Pillow-9.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:808add66ea764ed97d44dda1ac4f2cfec4c1867d9efb16a33d158be79f32b8a4"},
-    {file = "Pillow-9.2.0-cp39-cp39-win32.whl", hash = "sha256:337a74fd2f291c607d220c793a8135273c4c2ab001b03e601c36766005f36885"},
-    {file = "Pillow-9.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:fac2d65901fb0fdf20363fbd345c01958a742f2dc62a8dd4495af66e3ff502a4"},
-    {file = "Pillow-9.2.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ad2277b185ebce47a63f4dc6302e30f05762b688f8dc3de55dbae4651872cdf3"},
-    {file = "Pillow-9.2.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c7b502bc34f6e32ba022b4a209638f9e097d7a9098104ae420eb8186217ebbb"},
-    {file = "Pillow-9.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d1f14f5f691f55e1b47f824ca4fdcb4b19b4323fe43cc7bb105988cad7496be"},
-    {file = "Pillow-9.2.0-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:dfe4c1fedfde4e2fbc009d5ad420647f7730d719786388b7de0999bf32c0d9fd"},
-    {file = "Pillow-9.2.0-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:f07f1f00e22b231dd3d9b9208692042e29792d6bd4f6639415d2f23158a80013"},
-    {file = "Pillow-9.2.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1802f34298f5ba11d55e5bb09c31997dc0c6aed919658dfdf0198a2fe75d5490"},
-    {file = "Pillow-9.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17d4cafe22f050b46d983b71c707162d63d796a1235cdf8b9d7a112e97b15bac"},
-    {file = "Pillow-9.2.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:96b5e6874431df16aee0c1ba237574cb6dff1dcb173798faa6a9d8b399a05d0e"},
-    {file = "Pillow-9.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:0030fdbd926fb85844b8b92e2f9449ba89607231d3dd597a21ae72dc7fe26927"},
-    {file = "Pillow-9.2.0.tar.gz", hash = "sha256:75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04"},
+    {file = "Pillow-9.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:0b7257127d646ff8676ec8a15520013a698d1fdc48bc2a79ba4e53df792526f2"},
+    {file = "Pillow-9.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b90f7616ea170e92820775ed47e136208e04c967271c9ef615b6fbd08d9af0e3"},
+    {file = "Pillow-9.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68943d632f1f9e3dce98908e873b3a090f6cba1cbb1b892a9e8d97c938871fbe"},
+    {file = "Pillow-9.3.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be55f8457cd1eac957af0c3f5ece7bc3f033f89b114ef30f710882717670b2a8"},
+    {file = "Pillow-9.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d77adcd56a42d00cc1be30843d3426aa4e660cab4a61021dc84467123f7a00c"},
+    {file = "Pillow-9.3.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:829f97c8e258593b9daa80638aee3789b7df9da5cf1336035016d76f03b8860c"},
+    {file = "Pillow-9.3.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:801ec82e4188e935c7f5e22e006d01611d6b41661bba9fe45b60e7ac1a8f84de"},
+    {file = "Pillow-9.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:871b72c3643e516db4ecf20efe735deb27fe30ca17800e661d769faab45a18d7"},
+    {file = "Pillow-9.3.0-cp310-cp310-win32.whl", hash = "sha256:655a83b0058ba47c7c52e4e2df5ecf484c1b0b0349805896dd350cbc416bdd91"},
+    {file = "Pillow-9.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:9f47eabcd2ded7698106b05c2c338672d16a6f2a485e74481f524e2a23c2794b"},
+    {file = "Pillow-9.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:57751894f6618fd4308ed8e0c36c333e2f5469744c34729a27532b3db106ee20"},
+    {file = "Pillow-9.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7db8b751ad307d7cf238f02101e8e36a128a6cb199326e867d1398067381bff4"},
+    {file = "Pillow-9.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3033fbe1feb1b59394615a1cafaee85e49d01b51d54de0cbf6aa8e64182518a1"},
+    {file = "Pillow-9.3.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22b012ea2d065fd163ca096f4e37e47cd8b59cf4b0fd47bfca6abb93df70b34c"},
+    {file = "Pillow-9.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9a65733d103311331875c1dca05cb4606997fd33d6acfed695b1232ba1df193"},
+    {file = "Pillow-9.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:502526a2cbfa431d9fc2a079bdd9061a2397b842bb6bc4239bb176da00993812"},
+    {file = "Pillow-9.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:90fb88843d3902fe7c9586d439d1e8c05258f41da473952aa8b328d8b907498c"},
+    {file = "Pillow-9.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:89dca0ce00a2b49024df6325925555d406b14aa3efc2f752dbb5940c52c56b11"},
+    {file = "Pillow-9.3.0-cp311-cp311-win32.whl", hash = "sha256:3168434d303babf495d4ba58fc22d6604f6e2afb97adc6a423e917dab828939c"},
+    {file = "Pillow-9.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:18498994b29e1cf86d505edcb7edbe814d133d2232d256db8c7a8ceb34d18cef"},
+    {file = "Pillow-9.3.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:772a91fc0e03eaf922c63badeca75e91baa80fe2f5f87bdaed4280662aad25c9"},
+    {file = "Pillow-9.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa4107d1b306cdf8953edde0534562607fe8811b6c4d9a486298ad31de733b2"},
+    {file = "Pillow-9.3.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4012d06c846dc2b80651b120e2cdd787b013deb39c09f407727ba90015c684f"},
+    {file = "Pillow-9.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77ec3e7be99629898c9a6d24a09de089fa5356ee408cdffffe62d67bb75fdd72"},
+    {file = "Pillow-9.3.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:6c738585d7a9961d8c2821a1eb3dcb978d14e238be3d70f0a706f7fa9316946b"},
+    {file = "Pillow-9.3.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:828989c45c245518065a110434246c44a56a8b2b2f6347d1409c787e6e4651ee"},
+    {file = "Pillow-9.3.0-cp37-cp37m-win32.whl", hash = "sha256:82409ffe29d70fd733ff3c1025a602abb3e67405d41b9403b00b01debc4c9a29"},
+    {file = "Pillow-9.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:41e0051336807468be450d52b8edd12ac60bebaa97fe10c8b660f116e50b30e4"},
+    {file = "Pillow-9.3.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:b03ae6f1a1878233ac620c98f3459f79fd77c7e3c2b20d460284e1fb370557d4"},
+    {file = "Pillow-9.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4390e9ce199fc1951fcfa65795f239a8a4944117b5935a9317fb320e7767b40f"},
+    {file = "Pillow-9.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40e1ce476a7804b0fb74bcfa80b0a2206ea6a882938eaba917f7a0f004b42502"},
+    {file = "Pillow-9.3.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a0a06a052c5f37b4ed81c613a455a81f9a3a69429b4fd7bb913c3fa98abefc20"},
+    {file = "Pillow-9.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03150abd92771742d4a8cd6f2fa6246d847dcd2e332a18d0c15cc75bf6703040"},
+    {file = "Pillow-9.3.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:15c42fb9dea42465dfd902fb0ecf584b8848ceb28b41ee2b58f866411be33f07"},
+    {file = "Pillow-9.3.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:51e0e543a33ed92db9f5ef69a0356e0b1a7a6b6a71b80df99f1d181ae5875636"},
+    {file = "Pillow-9.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3dd6caf940756101205dffc5367babf288a30043d35f80936f9bfb37f8355b32"},
+    {file = "Pillow-9.3.0-cp38-cp38-win32.whl", hash = "sha256:f1ff2ee69f10f13a9596480335f406dd1f70c3650349e2be67ca3139280cade0"},
+    {file = "Pillow-9.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:276a5ca930c913f714e372b2591a22c4bd3b81a418c0f6635ba832daec1cbcfc"},
+    {file = "Pillow-9.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:73bd195e43f3fadecfc50c682f5055ec32ee2c933243cafbfdec69ab1aa87cad"},
+    {file = "Pillow-9.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1c7c8ae3864846fc95f4611c78129301e203aaa2af813b703c55d10cc1628535"},
+    {file = "Pillow-9.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e0918e03aa0c72ea56edbb00d4d664294815aa11291a11504a377ea018330d3"},
+    {file = "Pillow-9.3.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0915e734b33a474d76c28e07292f196cdf2a590a0d25bcc06e64e545f2d146c"},
+    {file = "Pillow-9.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af0372acb5d3598f36ec0914deed2a63f6bcdb7b606da04dc19a88d31bf0c05b"},
+    {file = "Pillow-9.3.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:ad58d27a5b0262c0c19b47d54c5802db9b34d38bbf886665b626aff83c74bacd"},
+    {file = "Pillow-9.3.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:97aabc5c50312afa5e0a2b07c17d4ac5e865b250986f8afe2b02d772567a380c"},
+    {file = "Pillow-9.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9aaa107275d8527e9d6e7670b64aabaaa36e5b6bd71a1015ddd21da0d4e06448"},
+    {file = "Pillow-9.3.0-cp39-cp39-win32.whl", hash = "sha256:bac18ab8d2d1e6b4ce25e3424f709aceef668347db8637c2296bcf41acb7cf48"},
+    {file = "Pillow-9.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:b472b5ea442148d1c3e2209f20f1e0bb0eb556538690fa70b5e1f79fa0ba8dc2"},
+    {file = "Pillow-9.3.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ab388aaa3f6ce52ac1cb8e122c4bd46657c15905904b3120a6248b5b8b0bc228"},
+    {file = "Pillow-9.3.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbb8e7f2abee51cef77673be97760abff1674ed32847ce04b4af90f610144c7b"},
+    {file = "Pillow-9.3.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bca31dd6014cb8b0b2db1e46081b0ca7d936f856da3b39744aef499db5d84d02"},
+    {file = "Pillow-9.3.0-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c7025dce65566eb6e89f56c9509d4f628fddcedb131d9465cacd3d8bac337e7e"},
+    {file = "Pillow-9.3.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ebf2029c1f464c59b8bdbe5143c79fa2045a581ac53679733d3a91d400ff9efb"},
+    {file = "Pillow-9.3.0-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b59430236b8e58840a0dfb4099a0e8717ffb779c952426a69ae435ca1f57210c"},
+    {file = "Pillow-9.3.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12ce4932caf2ddf3e41d17fc9c02d67126935a44b86df6a206cf0d7161548627"},
+    {file = "Pillow-9.3.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae5331c23ce118c53b172fa64a4c037eb83c9165aba3a7ba9ddd3ec9fa64a699"},
+    {file = "Pillow-9.3.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0b07fffc13f474264c336298d1b4ce01d9c5a011415b79d4ee5527bb69ae6f65"},
+    {file = "Pillow-9.3.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:073adb2ae23431d3b9bcbcff3fe698b62ed47211d0716b067385538a1b0f28b8"},
+    {file = "Pillow-9.3.0.tar.gz", hash = "sha256:c935a22a557a560108d780f9a0fc426dd7459940dc54faa49d83249c8d3e760f"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -1934,24 +1922,27 @@ pycparser = [
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pyexiv2 = [
-    {file = "pyexiv2-2.8.0-cp310-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:f0a60742ba8789d9580d5a2600de72d7f23ac3cde7cf04b8b10aefab8d1e5bd6"},
-    {file = "pyexiv2-2.8.0-cp310-none-manylinux2014_x86_64.whl", hash = "sha256:3031ea4f12981fccfad4cee275c7fc18df664c75bee6bfca2f15d5b8ed477c9d"},
-    {file = "pyexiv2-2.8.0-cp310-none-win_amd64.whl", hash = "sha256:ec03102b313f1a9e1a2c0d2745518d4e693d3811f8295b3dccd5950820e4c724"},
-    {file = "pyexiv2-2.8.0-cp35-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:6e8930c5acfb45f3da355e1b27855123c5c943f2b795c8410b47a8fe3f947496"},
-    {file = "pyexiv2-2.8.0-cp35-none-manylinux2014_x86_64.whl", hash = "sha256:daa1f1ff0daa04b79f7f4853ea5055e012528da922496efcd912898e954c5905"},
-    {file = "pyexiv2-2.8.0-cp35-none-win_amd64.whl", hash = "sha256:2fd0e1626c96c1d0302b76d79d9ff3a3a631131a67685799c6781d9cbb10ae0f"},
-    {file = "pyexiv2-2.8.0-cp36-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:840bf48fe7114533ee9782296dd81817b6ffb96e2043392dc13319d196478178"},
-    {file = "pyexiv2-2.8.0-cp36-none-manylinux2014_x86_64.whl", hash = "sha256:09dd035e800bb068b4c23f505ebc868b5b55a20d3d1347523336fb88c547297e"},
-    {file = "pyexiv2-2.8.0-cp36-none-win_amd64.whl", hash = "sha256:dc5b7fa958aa890ffd6b1281ea200997a80aaafc057435decfb6fb7ace1217c9"},
-    {file = "pyexiv2-2.8.0-cp37-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:7796ee9cf46abd707bfa31f948d71e2e02db67b01f7705861afaccc701972818"},
-    {file = "pyexiv2-2.8.0-cp37-none-manylinux2014_x86_64.whl", hash = "sha256:c19a1a06e1c4b4235b2a4750dddbc8e8a55dd3ada366974d5c0525b2d6493e5c"},
-    {file = "pyexiv2-2.8.0-cp37-none-win_amd64.whl", hash = "sha256:63fd49ea4ba94201b122741707e05de506104afe71e3283d297e42d55e483a31"},
-    {file = "pyexiv2-2.8.0-cp38-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:6877bb1e48f804079f4b5b994163e46e66fc6ce5827fd06710fd80d952e5de87"},
-    {file = "pyexiv2-2.8.0-cp38-none-manylinux2014_x86_64.whl", hash = "sha256:3fb040c4487d92369a02f53039affbdb7699864ffc68aaa2a79d22c47575832e"},
-    {file = "pyexiv2-2.8.0-cp38-none-win_amd64.whl", hash = "sha256:aa3c7accfdbc0e7128f54b71eed9c108925b1feef41d8c089a813fdffcdedf8d"},
-    {file = "pyexiv2-2.8.0-cp39-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:faac1de8ecacfd4a820bf0b518c7923cc1be537295f945d66e556e3dcfa11791"},
-    {file = "pyexiv2-2.8.0-cp39-none-manylinux2014_x86_64.whl", hash = "sha256:3a7136dcce7faf650134194a6189b7ad522ec1e8f16cdb035924f5e85e019e18"},
-    {file = "pyexiv2-2.8.0-cp39-none-win_amd64.whl", hash = "sha256:05b51c60d4636dffe82aced2950ef62fa6ce45b857d50c9d419fb408e67b33de"},
+    {file = "pyexiv2-2.8.1-cp310-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:1133b63bc66dc4ee0d958394d46cc371f63570530dcd6c95ff0986c39ad9bab6"},
+    {file = "pyexiv2-2.8.1-cp310-none-manylinux2014_x86_64.whl", hash = "sha256:8b115cb16fd543408d61c1cbd4d0e661f31b6502a6971fe22e63773d689903fb"},
+    {file = "pyexiv2-2.8.1-cp310-none-win_amd64.whl", hash = "sha256:0737e81373abb0966685063f8399a91a05dd4e978d93622cee3d11b696f031ab"},
+    {file = "pyexiv2-2.8.1-cp311-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:b92e61c49addd27a07133dcca61425e1d75f3f937de504e7c2b4680fabf88008"},
+    {file = "pyexiv2-2.8.1-cp311-none-manylinux2014_x86_64.whl", hash = "sha256:d5eb6003a8dede4e97befc254c6af3bc1adad056254742510a1b990acf627cac"},
+    {file = "pyexiv2-2.8.1-cp311-none-win_amd64.whl", hash = "sha256:35833a98302ada1e98960823ea09dfa12612c5de2c0f8edd3dab6facaa12d64b"},
+    {file = "pyexiv2-2.8.1-cp35-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:c3070208251f8db985dc23879492144f67796e97c4cbe4d7b705e5a85ce3ce39"},
+    {file = "pyexiv2-2.8.1-cp35-none-manylinux2014_x86_64.whl", hash = "sha256:e8dfdbdc32b68991c79c8c434cb956f5a78cdbe180c0cbb61905588560613956"},
+    {file = "pyexiv2-2.8.1-cp35-none-win_amd64.whl", hash = "sha256:a8aa0c9e102ce8e17aa60ef597d355c13b730aa47df01e5fccef8fb73c04e822"},
+    {file = "pyexiv2-2.8.1-cp36-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:c76f90b69067b2fb047e807fc40c76e81a9a1b691604634b6fbc934f6fea64fd"},
+    {file = "pyexiv2-2.8.1-cp36-none-manylinux2014_x86_64.whl", hash = "sha256:8726df6c0ad5b4e9a052dc18db8a397c3412d4a6d22b58c846a9093f0777176d"},
+    {file = "pyexiv2-2.8.1-cp36-none-win_amd64.whl", hash = "sha256:13e224b500b63018f7c58d154eeb770f5d39c4c06c02341e93780b00b83e55fb"},
+    {file = "pyexiv2-2.8.1-cp37-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:65aca28c3b28a6a395bef484578eb167cdbd709f021147d844924b24c0ce4bd6"},
+    {file = "pyexiv2-2.8.1-cp37-none-manylinux2014_x86_64.whl", hash = "sha256:7947f233e6790412dbb51714e795531cca48db8c9e0d85216c729ae0ff578ef5"},
+    {file = "pyexiv2-2.8.1-cp37-none-win_amd64.whl", hash = "sha256:32c11eb6b725f5a870400cd733ace83d5a16a7260bd4918596a745d517d21dda"},
+    {file = "pyexiv2-2.8.1-cp38-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:0982404a1932115fd001c148ceb14ac5be570d4312e3e5ba42ef90a0231f8278"},
+    {file = "pyexiv2-2.8.1-cp38-none-manylinux2014_x86_64.whl", hash = "sha256:1b7a26481bed04e223a905ec1f1b1bc9b1d1c88653c7c4ee94bd35f22582cdaf"},
+    {file = "pyexiv2-2.8.1-cp38-none-win_amd64.whl", hash = "sha256:150ab423a9addf642309be2dc2ac820d7f8e08a6b72bc2e2fef3abdba480284a"},
+    {file = "pyexiv2-2.8.1-cp39-none-macosx_10_14_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:5626b6f69ea5da685692410dfe8dba05c286ffc55aebccd76300bade6c84c3ec"},
+    {file = "pyexiv2-2.8.1-cp39-none-manylinux2014_x86_64.whl", hash = "sha256:de719c05592ccf78aa444484c614b58e2f6c1d54825a21bb2a0c922b4534f9da"},
+    {file = "pyexiv2-2.8.1-cp39-none-win_amd64.whl", hash = "sha256:b2d31ca96bfda2ba3bd7bcbdf798f4ca2e8b0ee4786974b34391f376acdbbd32"},
 ]
 Pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
@@ -1965,25 +1956,29 @@ pyinaturalist-convert = [
     {file = "pyinaturalist_convert-0.6.0.dev0-py3-none-any.whl", hash = "sha256:864fb8c7ad89912cbf5fb0737f52bc2a5ae768888fc2c536c68ae4e8ffc9b930"},
 ]
 pyinstaller = [
-    {file = "pyinstaller-5.6.1-py3-none-macosx_10_13_universal2.whl", hash = "sha256:0465edb7a5b2bc74ac983d419fd980fd2e4c7d49f4c013edd4befb6ca70d3c2b"},
-    {file = "pyinstaller-5.6.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:556750250bba85cf7ede168994fe70fcdeeba8d22f51eaedfd94b3efb6faa6ce"},
-    {file = "pyinstaller-5.6.1-py3-none-manylinux2014_i686.whl", hash = "sha256:2abb74b008f01a8d9b54c27ea51aa6d59ea6137d507de9d580f79b934e0ca7b8"},
-    {file = "pyinstaller-5.6.1-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:bb3faba1a29686e1c2d71a939bc6d1a57ca218d6968f43620591df42058635e0"},
-    {file = "pyinstaller-5.6.1-py3-none-manylinux2014_s390x.whl", hash = "sha256:b8dc59b00bc09053ed0476b47423373fafb8f4d57618e9eff7047cda8942e1c4"},
-    {file = "pyinstaller-5.6.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:14a0bb008966ba074e173f94b5bffd78a4d84e4a21fafc63c1b72851a40a918d"},
-    {file = "pyinstaller-5.6.1-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:8c423556f0aac7651cda813db0d215c36c51717c4079e407136a4d9f730d38b0"},
-    {file = "pyinstaller-5.6.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:a64a5472ee36f63e773be63535817b6d8aea1c1cf9acd18858c22c66fe575043"},
-    {file = "pyinstaller-5.6.1-py3-none-win32.whl", hash = "sha256:fc734eb91e08c75fc7505170d765a49d781dad9e49dd641ebe4f8a82782f0be2"},
-    {file = "pyinstaller-5.6.1-py3-none-win_amd64.whl", hash = "sha256:ec9d9491681ac55e369a5226833694bf299ddeaeab6df4ef9d44758d4342f10a"},
-    {file = "pyinstaller-5.6.1.tar.gz", hash = "sha256:a7fac3fa8f75bce2839e0ab910baf0e935ff2b5f327c32aedade563e1b610967"},
+    {file = "pyinstaller-5.6.2-py3-none-macosx_10_13_universal2.whl", hash = "sha256:1b1e3b37a22fb36555d917f0c3dfb998159ff4af6d8fa7cc0074d630c6fe81ad"},
+    {file = "pyinstaller-5.6.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:05df5d2b9ca645cc6ef61d8a85451d2aabe5501997f1f50cd94306fd6bc0485d"},
+    {file = "pyinstaller-5.6.2-py3-none-manylinux2014_i686.whl", hash = "sha256:eb083c25f711769af0898852ea30dcb727ba43990bbdf9ffbaa9c77a7bd0d720"},
+    {file = "pyinstaller-5.6.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:0d167d57036219914188f1400427dd297b975707e78c32a5511191e607be920a"},
+    {file = "pyinstaller-5.6.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:32727232f446aa96e394f01b0c35b3de0dc3513c6ba3e26d1ef64c57edb1e9e5"},
+    {file = "pyinstaller-5.6.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:181856ade585b090379ae26b7017dc2c30620e36e3a804b381417a6dc3b2a82b"},
+    {file = "pyinstaller-5.6.2-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:77888f52b61089caa0bee70809bbce9e9b1c613c88b6cb0742ff2a45f1511cbb"},
+    {file = "pyinstaller-5.6.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:d888db9afedff290d362ee296d30eb339abeba707ca1565916ce1cd5947131c3"},
+    {file = "pyinstaller-5.6.2-py3-none-win32.whl", hash = "sha256:e026adc92c60158741d0bfca27eefaa2414801f61328cb84d0c88241fe8c2087"},
+    {file = "pyinstaller-5.6.2-py3-none-win_amd64.whl", hash = "sha256:04ecf805bde2ef25b8e3642410871e6747c22fa7254107f155b8cd179c2a13b6"},
+    {file = "pyinstaller-5.6.2.tar.gz", hash = "sha256:865025b6809d777bb0f66d8f8ab50cc97dc3dbe0ff09a1ef1f2fd646432714fc"},
 ]
 pyinstaller-hooks-contrib = [
-    {file = "pyinstaller-hooks-contrib-2022.10.tar.gz", hash = "sha256:e5edd4094175e78c178ef987b61be19efff6caa23d266ade456fc753e847f62e"},
-    {file = "pyinstaller_hooks_contrib-2022.10-py2.py3-none-any.whl", hash = "sha256:d1dd6ea059dc30e77813cc12a5efa8b1d228e7da8f5b884fe11775f946db1784"},
+    {file = "pyinstaller-hooks-contrib-2022.11.tar.gz", hash = "sha256:2e1870350bb9ef2e09c1c1bb30347eb3185c5ef38c040ed04190d6d0b4b5df62"},
+    {file = "pyinstaller_hooks_contrib-2022.11-py2.py3-none-any.whl", hash = "sha256:8db4064d9c127940455ec363bebbf74228be21cdafb44f7ea4f44cf434d9bcaa"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pyqtdarktheme = [
+    {file = "pyqtdarktheme-1.1.1-py3-none-any.whl", hash = "sha256:78710a6eabd9e86ff6ac26fc382ae51921f5e55b397be3d834321359e7988524"},
+    {file = "pyqtdarktheme-1.1.1.tar.gz", hash = "sha256:dce013ff6b2de8f7b5814f17bffb59a2690dda4df69cf0085c5d09dcd5452af4"},
 ]
 pyrate-limiter = [
     {file = "pyrate_limiter-2.8.3.tar.gz", hash = "sha256:9f464ed01fa647d4d1f32ce27b8db9d594ab787847ec4ae72e1f5498756dd33d"},
@@ -2023,8 +2018,8 @@ python-forge = [
     {file = "python_forge-18.6.0-py35-none-any.whl", hash = "sha256:bf91f9a42150d569c2e9a0d90ab60a8cbed378bdf185e5120532a3481067395c"},
 ]
 pytz = [
-    {file = "pytz-2022.5-py2.py3-none-any.whl", hash = "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22"},
-    {file = "pytz-2022.5.tar.gz", hash = "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"},
+    {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},
+    {file = "pytz-2022.6.tar.gz", hash = "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
@@ -2075,10 +2070,6 @@ PyYAML = [
 QtAwesome = [
     {file = "QtAwesome-1.2.1-py3-none-any.whl", hash = "sha256:abc465da18158a4f2973406ae0ecd6c1daf87ddcd950e3a46497b708dd9674b3"},
     {file = "QtAwesome-1.2.1.tar.gz", hash = "sha256:f440dcab3d4fc8acfa5875c8c565d7bd58e537967a703679484c5c567be3f120"},
-]
-qtmodern = [
-    {file = "qtmodern-0.2.0-py3-none-any.whl", hash = "sha256:57e62617656494a9d8a27ac3bd51ae3ae61a265f43b92d6f6ea59dc8bed2179d"},
-    {file = "qtmodern-0.2.0.tar.gz", hash = "sha256:d433a54fbb400d49790aff65d35f203de2a8cc67795ac5bb04c5e766433fafae"},
 ]
 QtPy = [
     {file = "QtPy-2.2.1-py3-none-any.whl", hash = "sha256:268cf5328f41353be1b127e04a81bc74ec9a9b54c9ac75dd8fe0ff48d8ad6ead"},
@@ -2229,8 +2220,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.11.5-py3-none-any.whl", hash = "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"},
-    {file = "tomlkit-0.11.5.tar.gz", hash = "sha256:571854ebbb5eac89abcb4a2e47d7ea27b89bf29e09c35395da6f03dd4ae23d1c"},
+    {file = "tomlkit-0.11.6-py3-none-any.whl", hash = "sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b"},
+    {file = "tomlkit-0.11.6.tar.gz", hash = "sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,12 @@ pyinaturalist               = '0.18.0dev0'
 # pyinaturalist-convert       = {git="https://github.com/pyinat/pyinaturalist-convert.git"}
 pyinaturalist-convert       = '0.6.0dev0'
 pyside6                     = '6.3.0'
-# TODO: Update to 6.4.0 when pyqt releases compatibility fixes
+# TODO: Update to 6.4.0 when qtpy releases compatibility fixes
+#   Currently causes: AttributeError('Cannot reassign members.')
 # pyside6                     = '^6.4.0'
+pyqtdarktheme               = "^1.1.1"
 pyyaml                      = '>=6.0'
 qtawesome                   = '^1.1.1'
-qtmodern                    = '^0.2'
 sqlalchemy                  = '^1.4.36'
 
 # Documentation dependencies needed for Readthedocs builds


### PR DESCRIPTION
Updates #203

Lots of misc improvements:

- Use pyqtdarktheme instead of qtmodern, and fix custom stylesheet and palette to be compatible
- Fix infocard title text stealing mouse focus on click events
- Disable main taxon/observation photo hover and click events until first photo is loaded
- Fix cutoff issue for small icons
- Fix padding of metadata icons
- Fix alignment/padding for taxon rank dropdowns
- Draw rounded corners on thumbnails
- Fix casing for common names with apostrophes on TaxonInfoCards
- Minor fix for null identifications
