### PR TITLE
Main app refactoring

### DIFF
--- a/naturtag/app/__init__.py
+++ b/naturtag/app/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa: F401
+from naturtag.app.app import NaturtagApp

--- a/naturtag/app/settings_menu.py
+++ b/naturtag/app/settings_menu.py
@@ -25,78 +25,116 @@ logger = getLogger(__name__)
 class SettingsMenu(BaseController):
     """Application settings menu, with input widgets connected to values in settings file"""
 
-    def __init__(self, settings: Settings):
-        super().__init__(settings)
-        self.settings = settings
+    def __init__(self):
+        super().__init__()
         self.settings_layout = VerticalLayout(self)
         # Dictionary of locale codes and display names
         self.locales = {k: f'{v} ({k})' for k, v in read_locales().items()}
 
         # iNaturalist settings
         inat = self.add_group('iNaturalist', self.settings_layout)
-        inat.addLayout(TextSetting(settings, icon_str='fa.user', setting_attr='username'))
+        inat.addLayout(
+            TextSetting(
+                self.app.settings,
+                icon_str='fa.user',
+                setting_attr='username',
+            )
+        )
         inat.addLayout(
             ChoiceAltDisplaySetting(
-                settings,
+                self.app.settings,
                 icon_str='fa.globe',
                 setting_attr='locale',
                 choices=self.locales,
             )
         )
         inat.addLayout(
-            ToggleSetting(settings, icon_str='fa.language', setting_attr='search_locale')
-        )
-        inat.addLayout(
-            IntSetting(
-                settings, icon_str='mdi.home-city-outline', setting_attr='preferred_place_id'
+            ToggleSetting(
+                self.app.settings,
+                icon_str='fa.language',
+                setting_attr='search_locale',
             )
         )
         inat.addLayout(
-            ToggleSetting(settings, icon_str='mdi6.cat', setting_attr='casual_observations')
+            IntSetting(
+                self.app.settings,
+                icon_str='mdi.home-city-outline',
+                setting_attr='preferred_place_id',
+            )
+        )
+        inat.addLayout(
+            ToggleSetting(
+                self.app.settings,
+                icon_str='mdi6.cat',
+                setting_attr='casual_observations',
+            )
         )
         self.all_ranks = ToggleSetting(
-            settings, icon_str='fa.chevron-circle-up', setting_attr='all_ranks'
+            self.app.settings,
+            icon_str='fa.chevron-circle-up',
+            setting_attr='all_ranks',
         )
         inat.addLayout(self.all_ranks)
 
         # Metadata settings
         metadata = self.add_group('Metadata', self.settings_layout)
         metadata.addLayout(
-            ToggleSetting(settings, icon_str='fa.language', setting_attr='common_names')
-        )
-        metadata.addLayout(
-            ToggleSetting(settings, icon_str='mdi.file-tree', setting_attr='hierarchical')
-        )
-        metadata.addLayout(
-            ToggleSetting(settings, icon_str='fa5s.file-code', setting_attr='sidecar')
-        )
-        metadata.addLayout(
             ToggleSetting(
-                settings, icon_str='fa5s.file-alt', setting_attr='exif', setting_title='EXIF'
+                self.app.settings,
+                icon_str='fa.language',
+                setting_attr='common_names',
             )
         )
         metadata.addLayout(
             ToggleSetting(
-                settings, icon_str='fa5s.file-alt', setting_attr='iptc', setting_title='IPTC'
+                self.app.settings,
+                icon_str='mdi.file-tree',
+                setting_attr='hierarchical',
             )
         )
         metadata.addLayout(
             ToggleSetting(
-                settings, icon_str='fa5s.file-alt', setting_attr='xmp', setting_title='XMP'
+                self.app.settings,
+                icon_str='fa5s.file-code',
+                setting_attr='sidecar',
+            )
+        )
+        metadata.addLayout(
+            ToggleSetting(
+                self.app.settings,
+                icon_str='fa5s.file-alt',
+                setting_attr='exif',
+                setting_title='EXIF',
+            )
+        )
+        metadata.addLayout(
+            ToggleSetting(
+                self.app.settings,
+                icon_str='fa5s.file-alt',
+                setting_attr='iptc',
+                setting_title='IPTC',
+            )
+        )
+        metadata.addLayout(
+            ToggleSetting(
+                self.app.settings,
+                icon_str='fa5s.file-alt',
+                setting_attr='xmp',
+                setting_title='XMP',
             )
         )
 
         # User data settings
         user_data = self.add_group('User Data', self.settings_layout)
         use_last_dir = ToggleSetting(
-            settings,
+            self.app.settings,
             icon_str='mdi.folder-clock-outline',
             setting_attr='use_last_dir',
             setting_title='Use last directory',
         )
         user_data.addLayout(use_last_dir)
         self.default_image_dir = PathSetting(
-            settings,
+            self.app.settings,
             icon_str='fa5.images',
             setting_attr='default_image_dir',
             setting_title='Default image directory',
@@ -105,7 +143,7 @@ class SettingsMenu(BaseController):
         user_data.addLayout(self.default_image_dir)
 
         # Disable default_image_dir option when use_last_dir is enabled
-        self.default_image_dir.setEnabled(not settings.use_last_dir)
+        self.default_image_dir.setEnabled(not self.app.settings.use_last_dir)
         use_last_dir.on_click.connect(
             lambda checked: self.default_image_dir.setEnabled(not checked)
         )
@@ -113,7 +151,7 @@ class SettingsMenu(BaseController):
         # Display settings
         display = self.add_group('Display', self.settings_layout)
         self.dark_mode = ToggleSetting(
-            settings,
+            self.app.settings,
             icon_str='mdi.theme-light-dark',
             setting_attr='dark_mode',
         )
@@ -122,13 +160,13 @@ class SettingsMenu(BaseController):
         # Debug settings
         debug = self.add_group('Debug', self.settings_layout)
         self.show_logs = ToggleSetting(
-            settings,
+            self.app.settings,
             icon_str='fa.file-text-o',
             setting_attr='show_logs',
         )
         debug.addLayout(self.show_logs)
         self.log_level = ChoiceSetting(
-            settings,
+            self.app.settings,
             icon_str='fa.thermometer-2',
             setting_attr='log_level',
             choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
@@ -145,7 +183,7 @@ class SettingsMenu(BaseController):
 
     def closeEvent(self, event):
         """Save settings when closing the window"""
-        self.settings.write()
+        self.app.settings.write()
         self.on_message.emit('Settings saved')
         event.accept()
 

--- a/naturtag/cli.py
+++ b/naturtag/cli.py
@@ -21,9 +21,9 @@ from rich.logging import RichHandler
 from rich.table import Column, Table
 
 from naturtag.constants import CLI_COMPLETE_DIR
-from naturtag.metadata import KeywordMetadata, MetaMetadata, refresh_tags, strip_url, tag_images
+from naturtag.metadata import KeywordMetadata, MetaMetadata, refresh_tags, tag_images
 from naturtag.settings import Settings, setup
-from naturtag.utils.image_glob import get_valid_image_paths
+from naturtag.utils import get_valid_image_paths, strip_url
 
 CODE_BLOCK = re.compile(r'```\n\s*(.+?)```\n', re.DOTALL)
 CODE_INLINE = re.compile(r'`([^`]+?)`')

--- a/naturtag/client.py
+++ b/naturtag/client.py
@@ -268,8 +268,3 @@ def get_url_hash(url: str) -> str:
     thumbnail_hash = md5(url.encode()).hexdigest()
     ext = Photo(url=url).ext
     return f'{thumbnail_hash}.{ext}'
-
-
-# TODO: Refactor to depend on app.client and session objects instead of these module-level globals
-INAT_CLIENT = iNatDbClient()
-IMG_SESSION = ImageSession()

--- a/naturtag/controllers/__init__.py
+++ b/naturtag/controllers/__init__.py
@@ -1,5 +1,16 @@
 # flake8: noqa: F401
 # isort: skip_file
+from typing import TYPE_CHECKING
+from PySide6.QtWidgets import QApplication
+
+
+if TYPE_CHECKING:
+    from naturtag.app import NaturtagApp
+
+
+def get_app() -> 'NaturtagApp':
+    return QApplication.instance()
+
 
 from naturtag.controllers.base_controller import BaseController
 from naturtag.controllers.image_gallery import ImageGallery

--- a/naturtag/controllers/base_controller.py
+++ b/naturtag/controllers/base_controller.py
@@ -1,10 +1,12 @@
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QApplication
 
-from naturtag.app.threadpool import ThreadPool
-from naturtag.settings import Settings
 from naturtag.widgets.layouts import StylableWidget
+
+if TYPE_CHECKING:
+    from naturtag.app import NaturtagApp
 
 
 class BaseController(StylableWidget):
@@ -12,7 +14,6 @@ class BaseController(StylableWidget):
 
     on_message = Signal(str)  #: Forward a message to status bar
 
-    def __init__(self, settings: Settings, threadpool: Optional[ThreadPool] = None):
-        super().__init__()
-        self.settings = settings
-        self.threadpool: ThreadPool = threadpool  # type: ignore
+    @property
+    def app(self) -> 'NaturtagApp':
+        return QApplication.instance()

--- a/naturtag/controllers/image_controller.py
+++ b/naturtag/controllers/image_controller.py
@@ -29,8 +29,8 @@ class ImageController(BaseController):
     on_select_observation_id = Signal(int)  #: An observation ID was entered
     on_select_observation_tab = Signal()  #: Request to switch to observation tab
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
+        super().__init__()
         photo_layout = VerticalLayout(self)
         top_section_layout = HorizontalLayout()
         top_section_layout.setAlignment(Qt.AlignLeft)
@@ -69,7 +69,7 @@ class ImageController(BaseController):
         self.input_taxon_id.on_clear.connect(self.data_source_card.clear)
 
         # Image gallery
-        self.gallery = ImageGallery(self.settings, self.threadpool)
+        self.gallery = ImageGallery()
         self.gallery.on_select_observation.connect(self.on_select_observation_tab)
         self.gallery.on_select_taxon.connect(self.on_select_taxon_tab)
         photo_layout.addWidget(self.gallery)
@@ -90,10 +90,16 @@ class ImageController(BaseController):
         logger.info(f'Tagging {len(image_paths)} images with metadata for {selected_id}')
 
         def tag_image(image_path):
-            return tag_images([image_path], obs_id, taxon_id, settings=self.settings)[0]
+            return tag_images(
+                [image_path],
+                obs_id,
+                taxon_id,
+                client=self.app.client,
+                settings=self.app.settings,
+            )[0]
 
         for image_path in image_paths:
-            future = self.threadpool.schedule(tag_image, image_path=image_path)
+            future = self.app.threadpool.schedule(tag_image, image_path=image_path)
             future.on_result.connect(self.update_metadata)
         self.info(f'{len(image_paths)} images tagged with metadata for {selected_id}')
 
@@ -111,8 +117,8 @@ class ImageController(BaseController):
             return
 
         for image in images:
-            future = self.threadpool.schedule(
-                lambda: _refresh_tags(image.metadata, self.settings),
+            future = self.app.threadpool.schedule(
+                lambda: _refresh_tags(image.metadata, self.app.client, self.app.settings),
             )
             future.on_result.connect(self.update_metadata)
         self.info(f'{len(images)} images updated')

--- a/naturtag/controllers/image_controller.py
+++ b/naturtag/controllers/image_controller.py
@@ -6,7 +6,8 @@ from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import QApplication, QGroupBox, QLabel, QSizePolicy
 
 from naturtag.controllers import BaseController, ImageGallery
-from naturtag.metadata import MetaMetadata, _refresh_tags, get_ids_from_url, tag_images
+from naturtag.metadata import MetaMetadata, _refresh_tags, tag_images
+from naturtag.utils import get_ids_from_url
 from naturtag.widgets import (
     HorizontalLayout,
     IdInput,

--- a/naturtag/controllers/image_gallery.py
+++ b/naturtag/controllers/image_gallery.py
@@ -52,8 +52,8 @@ class ImageGallery(BaseController):
     on_select_taxon = Signal(int)  #: A taxon was selected from context menu
     on_select_observation = Signal(int)  #: An observation was selected from context menu
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
+        super().__init__()
         self.setAcceptDrops(True)
         self.images: dict[Path, ThumbnailCard] = {}
         self.image_window = ImageWindow()
@@ -82,7 +82,7 @@ class ImageGallery(BaseController):
         image_paths, _ = QFileDialog.getOpenFileNames(
             self,
             caption='Open image files:',
-            dir=str(start_dir or self.settings.start_image_dir),
+            dir=str(start_dir or self.app.settings.start_image_dir),
             filter=f'Image files ({" ".join(IMAGE_FILETYPES)})',
         )
         self.load_images(image_paths)
@@ -100,7 +100,7 @@ class ImageGallery(BaseController):
 
         # Then load actual images
         for thumbnail_card in filter(None, cards):
-            thumbnail_card.load_image_async(self.threadpool)
+            thumbnail_card.load_image_async(self.app.threadpool)
 
         self.on_load_images.emit(new_images)
 

--- a/naturtag/controllers/observation_search.py
+++ b/naturtag/controllers/observation_search.py
@@ -4,15 +4,13 @@ from logging import getLogger
 from pyinaturalist import Observation
 from PySide6.QtCore import Qt
 
-from naturtag.settings import Settings
 from naturtag.widgets import VerticalLayout
 
 logger = getLogger(__name__)
 
 
 class ObservationSearch(VerticalLayout):
-    def __init__(self, settings: Settings):
+    def __init__(self):
         super().__init__()
         self.selected_observation: Observation = None
-        self.settings = settings
         self.setAlignment(Qt.AlignTop)

--- a/naturtag/controllers/observation_view.py
+++ b/naturtag/controllers/observation_view.py
@@ -18,6 +18,7 @@ from naturtag.widgets import (
     ObservationImageWindow,
     ObservationPhoto,
     VerticalLayout,
+    set_pixmap_async,
 )
 from naturtag.widgets.observation_images import GEOPRIVACY_ICONS, QUALITY_GRADE_ICONS
 
@@ -119,8 +120,9 @@ class ObservationInfoSection(HorizontalLayout):
         self.group_box.setTitle(obs.taxon.full_name)
         self.image.hover_event = True
         self.image.observation = obs
-        self.image.set_pixmap_async(
-            photo=obs.photos[0],  # TODO: add Observation.default_photo in pyinat
+        set_pixmap_async(
+            self.image,
+            photo=Observation.default_photo,
             priority=QThread.HighPriority,
         )
         self._update_nav_buttons()
@@ -131,7 +133,7 @@ class ObservationInfoSection(HorizontalLayout):
             thumb = ObservationPhoto(observation=obs, idx=i + 1, rounded=True)
             thumb.setFixedSize(*SIZE_SM)
             thumb.on_click.connect(self.image_window.display_observation_fullscreen)
-            thumb.set_pixmap_async(photo=photo, size='thumbnail')
+            set_pixmap_async(thumb, photo=photo, size='thumbnail')
             self.thumbnails.addWidget(thumb)
 
         # Load observation details

--- a/naturtag/controllers/observation_view.py
+++ b/naturtag/controllers/observation_view.py
@@ -10,7 +10,6 @@ from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtWidgets import QGroupBox, QLabel, QPushButton
 
 from naturtag.app.style import fa_icon
-from naturtag.app.threadpool import ThreadPool
 from naturtag.constants import SIZE_SM
 from naturtag.widgets import (
     GridLayout,
@@ -30,9 +29,8 @@ class ObservationInfoSection(HorizontalLayout):
 
     on_select = Signal(Observation)  #: An observation was selected
 
-    def __init__(self, threadpool: ThreadPool):
+    def __init__(self):
         super().__init__()
-        self.threadpool = threadpool
         self.hist_prev: deque[Observation] = deque()  # Viewing history for current session only
         self.hist_next: deque[Observation] = deque()  # Set when loading from history
         self.history_observation: Observation = None  # Set when loading from history, to avoid loop
@@ -122,7 +120,6 @@ class ObservationInfoSection(HorizontalLayout):
         self.image.hover_event = True
         self.image.observation = obs
         self.image.set_pixmap_async(
-            self.threadpool,
             photo=obs.photos[0],  # TODO: add Observation.default_photo in pyinat
             priority=QThread.HighPriority,
         )
@@ -134,7 +131,7 @@ class ObservationInfoSection(HorizontalLayout):
             thumb = ObservationPhoto(observation=obs, idx=i + 1, rounded=True)
             thumb.setFixedSize(*SIZE_SM)
             thumb.on_click.connect(self.image_window.display_observation_fullscreen)
-            thumb.set_pixmap_async(self.threadpool, photo=photo, size='thumbnail')
+            thumb.set_pixmap_async(photo=photo, size='thumbnail')
             self.thumbnails.addWidget(thumb)
 
         # Load observation details

--- a/naturtag/controllers/taxon_view.py
+++ b/naturtag/controllers/taxon_view.py
@@ -10,7 +10,6 @@ from PySide6.QtWidgets import QGroupBox, QPushButton
 
 from naturtag.app.style import fa_icon
 from naturtag.constants import SIZE_SM
-from naturtag.controllers import get_app
 from naturtag.settings import UserTaxa
 from naturtag.widgets import (
     GridLayout,
@@ -18,6 +17,7 @@ from naturtag.widgets import (
     TaxonImageWindow,
     TaxonInfoCard,
     TaxonList,
+    set_pixmap_async,
 )
 from naturtag.widgets.layouts import VerticalLayout
 from naturtag.widgets.taxon_images import TaxonPhoto
@@ -110,7 +110,7 @@ class TaxonInfoSection(HorizontalLayout):
         self.group_box.setTitle(taxon.full_name)
         self.image.hover_event = True
         self.image.taxon = taxon
-        self.image.set_pixmap_async(photo=taxon.default_photo, priority=QThread.HighPriority)
+        set_pixmap_async(self.image, photo=taxon.default_photo, priority=QThread.HighPriority)
         self._update_nav_buttons()
 
         # Load additional thumbnails
@@ -119,7 +119,7 @@ class TaxonInfoSection(HorizontalLayout):
             thumb = TaxonPhoto(taxon=taxon, idx=i + 1, rounded=True)
             thumb.setFixedSize(*SIZE_SM)
             thumb.on_click.connect(self.image_window.display_taxon_fullscreen)
-            thumb.set_pixmap_async(photo=photo, size='thumbnail')
+            set_pixmap_async(thumb, photo=photo, size='thumbnail')
             self.thumbnails.addWidget(thumb)
 
     def prev(self):

--- a/naturtag/metadata/__init__.py
+++ b/naturtag/metadata/__init__.py
@@ -7,10 +7,8 @@ from naturtag.metadata.gps_metadata import *
 from naturtag.metadata.keyword_metadata import KeywordMetadata
 from naturtag.metadata.meta_metadata import MetaMetadata
 from naturtag.metadata.inat_metadata import (
-    get_ids_from_url,
-    get_inat_metadata,
+    observation_to_metadata,
     _refresh_tags,
     refresh_tags,
-    strip_url,
     tag_images,
 )

--- a/naturtag/metadata/inat_metadata.py
+++ b/naturtag/metadata/inat_metadata.py
@@ -9,7 +9,7 @@ from typing import Iterable, Optional
 from pyinaturalist import Observation, Taxon
 from pyinaturalist_convert import to_dwc
 
-from naturtag.client import INAT_CLIENT, iNatDbClient
+from naturtag.client import iNatDbClient
 from naturtag.constants import COMMON_NAME_IGNORE_TERMS, COMMON_RANKS, PathOrStr
 from naturtag.metadata import MetaMetadata
 from naturtag.settings import Settings
@@ -55,8 +55,8 @@ def tag_images(
     Returns:
         Updated image metadata for each image
     """
-    client = client or INAT_CLIENT
     settings = settings or Settings.read()
+    client = client or iNatDbClient(settings.db_path)
 
     observation = client.from_ids(observation_id, taxon_id)
     if not observation:
@@ -115,8 +115,8 @@ def refresh_tags(
     Returns:
         Updated metadata objects for updated images only
     """
-    client = client or INAT_CLIENT
     settings = settings or Settings.read()
+    client = client or iNatDbClient(settings.db_path)
     metadata_objs = [
         _refresh_tags(MetaMetadata(image_path), client, settings)
         for image_path in get_valid_image_paths(

--- a/naturtag/utils/__init__.py
+++ b/naturtag/utils/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
 from naturtag.utils.i18n import read_locales
 from naturtag.utils.image_glob import get_valid_image_paths
+from naturtag.utils.parsing import get_ids_from_url, quote, strip_url
 from naturtag.utils.thumbnails import generate_thumbnail

--- a/naturtag/utils/parsing.py
+++ b/naturtag/utils/parsing.py
@@ -1,0 +1,38 @@
+"""Misc URL and string parsing utilities"""
+
+
+from typing import Optional
+from urllib.parse import urlparse
+
+from naturtag.constants import IntTuple
+
+
+def get_ids_from_url(url: str) -> IntTuple:
+    """If a URL is provided containing an ID, return the taxon or observation ID.
+
+    Returns:
+        ``(observation_id, taxon_id)``
+    """
+    observation_id, taxon_id = None, None
+    id = strip_url(url)
+
+    if 'observation' in url:
+        observation_id = id
+    elif 'taxa' in url:
+        taxon_id = id
+
+    return observation_id, taxon_id
+
+
+def strip_url(value: str) -> Optional[int]:
+    """If a URL is provided containing an ID, return just the ID"""
+    try:
+        path = urlparse(value).path
+        return int(path.split('/')[-1].split('-')[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def quote(s: str) -> str:
+    """Surround keyword in quotes if it contains whitespace"""
+    return f'"{s}"' if ' ' in s else s

--- a/naturtag/widgets/__init__.py
+++ b/naturtag/widgets/__init__.py
@@ -19,6 +19,8 @@ from naturtag.widgets.images import (
     InfoCardList,
     ImageWindow,
     PixmapLabel,
+    set_pixmap,
+    set_pixmap_async,
 )
 from naturtag.widgets.inputs import IdInput
 from naturtag.widgets.logger import QtRichHandler, init_handler

--- a/naturtag/widgets/images.py
+++ b/naturtag/widgets/images.py
@@ -17,8 +17,6 @@ from naturtag.widgets import StylableWidget, VerticalLayout
 from naturtag.widgets.layouts import GridLayout, HorizontalLayout
 
 if TYPE_CHECKING:
-    from naturtag.app.threadpool import ThreadPool
-
     MIXIN_BASE: TypeAlias = QWidget
 else:
     MIXIN_BASE = object
@@ -149,7 +147,6 @@ class PixmapLabel(QLabel):
 
     def set_pixmap_async(
         self,
-        threadpool: 'ThreadPool',
         priority: QThread.Priority = QThread.NormalPriority,
         path: Optional[PathOrStr] = None,
         photo: Optional[Photo] = None,
@@ -157,7 +154,9 @@ class PixmapLabel(QLabel):
         url: Optional[str] = None,
     ):
         """Fetch a photo from a separate thread, and render it in the main thread when complete"""
-        future = threadpool.schedule(
+        from naturtag.controllers import get_app
+
+        future = get_app().threadpool.schedule(
             self.get_pixmap,
             priority=priority,
             path=path,
@@ -370,9 +369,8 @@ class InfoCard(StylableWidget):
 class InfoCardList(StylableWidget):
     """A scrollable list of InfoCards"""
 
-    def __init__(self, threadpool: 'ThreadPool', parent: Optional[QWidget] = None):
+    def __init__(self, parent: Optional[QWidget] = None):
         super().__init__(parent)
-        self.threadpool = threadpool
         self.root = VerticalLayout(self)
         self.root.setAlignment(Qt.AlignTop)
         self.root.setContentsMargins(0, 5, 5, 0)
@@ -394,7 +392,7 @@ class InfoCardList(StylableWidget):
             self.root.insertWidget(idx, card)
         else:
             self.root.addWidget(card)
-        card.thumbnail.set_pixmap_async(self.threadpool, url=thumbnail_url)
+        card.thumbnail.set_pixmap_async(url=thumbnail_url)
 
     def clear(self):
         self.root.clear()

--- a/naturtag/widgets/logger.py
+++ b/naturtag/widgets/logger.py
@@ -22,7 +22,7 @@ def init_handler(
     root.setLevel(root_level)
     root.addHandler(qt_handler)
 
-    # iI a logfile is specified, add a FileHandler with a separate formatter
+    # If a logfile is specified, add a FileHandler with a separate formatter
     if logfile:
         handler = FileHandler(filename=str(logfile))
         handler.setFormatter(

--- a/naturtag/widgets/observation_images.py
+++ b/naturtag/widgets/observation_images.py
@@ -7,7 +7,14 @@ from pyinaturalist import Observation, Photo
 from PySide6.QtCore import Qt
 
 from naturtag.constants import SIZE_ICON_SM
-from naturtag.widgets.images import HoverPhoto, IconLabel, ImageWindow, InfoCard, InfoCardList
+from naturtag.widgets.images import (
+    HoverPhoto,
+    IconLabel,
+    ImageWindow,
+    InfoCard,
+    InfoCardList,
+    set_pixmap,
+)
 from naturtag.widgets.layouts import HorizontalLayout
 
 logger = getLogger(__name__)
@@ -41,8 +48,7 @@ class ObservationInfoCard(InfoCard):
         self.observation = obs
 
         if not delayed_load:
-            pixmap = self.thumbnail.get_pixmap(url=obs.default_photo.thumbnail_url)
-            self.thumbnail.setPixmap(pixmap)
+            set_pixmap(self.thumbnail, url=obs.default_photo.thumbnail_url)
 
         # Title: Taxon name
         if obs.taxon:
@@ -173,7 +179,7 @@ class ObservationImageWindow(ImageWindow):
         self.set_photo(self.selected_photo)
 
     def set_photo(self, photo: Photo):
-        self.image.setPixmap(self.image.get_pixmap(url=photo.original_url))
+        set_pixmap(self.image, url=photo.original_url)
 
     def remove_image(self):
         pass

--- a/naturtag/widgets/taxon_images.py
+++ b/naturtag/widgets/taxon_images.py
@@ -19,7 +19,6 @@ from naturtag.widgets import (
 )
 
 if TYPE_CHECKING:
-    from naturtag.app.threadpool import ThreadPool
     from naturtag.settings import UserTaxa
 
 ATTRIBUTION_STRIP_PATTERN = re.compile(r',?\s+uploaded by.*')
@@ -65,8 +64,8 @@ class TaxonInfoCard(InfoCard):
 class TaxonList(InfoCardList):
     """A scrollable list of TaxonInfoCards"""
 
-    def __init__(self, threadpool: 'ThreadPool', user_taxa: 'UserTaxa', **kwargs):
-        super().__init__(threadpool, **kwargs)
+    def __init__(self, user_taxa: 'UserTaxa', **kwargs):
+        super().__init__(**kwargs)
         self.user_taxa = user_taxa
 
     def add_taxon(self, taxon: Taxon, idx: Optional[int] = None) -> TaxonInfoCard:

--- a/naturtag/widgets/taxon_images.py
+++ b/naturtag/widgets/taxon_images.py
@@ -16,6 +16,7 @@ from naturtag.widgets import (
     ImageWindow,
     InfoCard,
     InfoCardList,
+    set_pixmap,
 )
 
 if TYPE_CHECKING:
@@ -42,8 +43,7 @@ class TaxonInfoCard(InfoCard):
         self.setFixedHeight(90)
         self.taxon = taxon
         if not delayed_load:
-            pixmap = self.thumbnail.get_pixmap(url=taxon.default_photo.thumbnail_url)
-            self.thumbnail.setPixmap(pixmap)
+            set_pixmap(self.thumbnail, url=taxon.default_photo.thumbnail_url)
 
         # Details
         self.title.setText(f'{taxon.rank.title()}: <i>{taxon.name}</i>')
@@ -128,7 +128,7 @@ class TaxonImageWindow(ImageWindow):
         self.set_photo(self.selected_photo)
 
     def set_photo(self, photo: Photo):
-        self.image.setPixmap(self.image.get_pixmap(url=photo.original_url))
+        set_pixmap(self.image, url=photo.original_url)
         attribution = (
             ATTRIBUTION_STRIP_PATTERN.sub('', photo.attribution or '')
             .replace('(c)', '©')


### PR DESCRIPTION
Just untangling a bit of spaghetti (and hopefully not adding more).

* Refactor `get_inat_metadata()` into `observation_to_metadata()` and `iNatDbClient.from_ids()`
* Use API client object attribute on main app instance instead of module-level object
* Use session object attribute on main app instance for fetching images instead of module-level object
* Access globally used objects via main app instance instead of passing them individually to controllers