### PR TITLE
Build and publish an AppImage package; use instead of snap as a Linux distro-agnostic option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           tar -C dist/naturtag/ -czvf naturtag-windows.tar.gz .
           echo 'DIST_NAME=windows' >> $GITHUB_ENV
 
-      # Build deb, snap, and rpm packages
+      # Build deb, rpm, and pacman packages
       - name: Build Linux packages with FPM
         if: startsWith(matrix.os, 'ubuntu')
         run: |
@@ -81,6 +81,11 @@ jobs:
           export PATH="$PATH:$GEM_HOME/bin"
           gem install fpm --user-install
           ./packaging/build_fpm.sh
+
+      # Build AppImage
+      - name: Build AppImage (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: ./packaging/build_appimage.sh
 
       # Inspect app bundle before signing
       - name: Inspect app bundle (macOS)
@@ -118,6 +123,13 @@ jobs:
         with:
           name: naturtag-fpm
           path: dist/naturtag.*
+
+      - name: Upload AppImage (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v6
+        with:
+          name: naturtag.AppImage
+          path: dist/naturtag.AppImage
 
   # Create a release with all workflow artifacts attached
   release-app-packages:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
 
 **Packaging:**
 * Build pacman package for Arch Linux
+* Build AppImage package for other Linux distros not covered by other formats (replaces snap package)
 * Include locale data in PyInstaller packages
 * Update packaged taxonomy db with iNaturalist data from February 2026
 * Upgrade to Qt 6.10

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,14 +45,14 @@ sudo pacman -U naturtag.pkg.tar.zst
 :::
 
 :::{tab-item} Linux (Other)
-For other Linux distributions, a [Snap](https://snapcraft.io/docs/installing-snapd)
-package is available. Download
+For other Linux distributions, a portable AppImage is available. Download
 {{
-    '[naturtag.snap](https://github.com/pyinat/naturtag/releases/download/{}/naturtag.snap)'.format(version)
+    '[naturtag.AppImage](https://github.com/pyinat/naturtag/releases/download/{}/naturtag.AppImage)'.format(version)
 }}
 and run:
 ```
-sudo snap install naturtag.snap
+chmod +x naturtag.AppImage
+./naturtag.AppImage
 ```
 :::
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -5,7 +5,8 @@ This directory contains scripts and config for building Naturtag packages in the
 * DMG package (macOS)
 * DEB package (Linux, Debian and derivatives)
 * RPM package (Linux, Fedora and derivatives)
-* Snap package (Linux)
+* pacman package (Linux, Arch and derivatives)
+* AppImage package (Linux)
 * Taxonomy full text search database (optional download)
 
 # Release steps

--- a/packaging/build_appimage.sh
+++ b/packaging/build_appimage.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Build an AppImage from the PyInstaller output
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+ASSETS_DIR=$ROOT_DIR/assets
+DIST_DIR=$ROOT_DIR/dist
+SRC_DIR=$DIST_DIR/naturtag
+APPDIR=$DIST_DIR/AppDir
+APPIMAGETOOL=$DIST_DIR/appimagetool
+
+# Download appimagetool if not already present
+if [ ! -f "$APPIMAGETOOL" ]; then
+    ARCH=$(uname -m)
+    curl -fsSL -o "$APPIMAGETOOL" \
+        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+    chmod +x "$APPIMAGETOOL"
+fi
+
+# Assemble AppDir
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/opt"
+mkdir -p "$APPDIR/usr/bin"
+mkdir -p "$APPDIR/usr/share/applications"
+mkdir -p "$APPDIR/usr/share/icons/hicolor/scalable/apps"
+
+# Copy PyInstaller output
+cp -r "$SRC_DIR" "$APPDIR/opt/naturtag"
+
+# Create AppRun launcher
+cat > "$APPDIR/AppRun" << 'EOF'
+#!/usr/bin/env bash
+SELF=$(readlink -f "$0")
+HERE=${SELF%/*}
+exec "$HERE/opt/naturtag/naturtag" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+# Copy desktop file with Exec= adjusted for AppImage
+sed 's|^Exec=.*|Exec=naturtag|; s|^Path=.*||' "$SCRIPT_DIR/naturtag.desktop" \
+    > "$APPDIR/naturtag.desktop"
+cp "$APPDIR/naturtag.desktop" "$APPDIR/usr/share/applications/"
+
+# Copy icon
+cp "$ASSETS_DIR/icons/logo.svg" "$APPDIR/naturtag.svg"
+cp "$ASSETS_DIR/icons/logo.svg" "$APPDIR/usr/share/icons/hicolor/scalable/apps/naturtag.svg"
+
+# Symlink main executable and set file permissions
+ln -sf ../../opt/naturtag/naturtag "$APPDIR/usr/bin/naturtag"
+find "$APPDIR/opt/naturtag/" -type f -exec chmod 644 -- {} +
+find "$APPDIR/opt/naturtag/" -type d -exec chmod 755 -- {} +
+chmod +x "$APPDIR/opt/naturtag/naturtag"
+
+# Build AppImage
+ARCH=$(uname -m) "$APPIMAGETOOL" "$APPDIR" "$DIST_DIR/naturtag.AppImage"
+echo "AppImage created: $DIST_DIR/naturtag.AppImage"

--- a/packaging/build_fpm.sh
+++ b/packaging/build_fpm.sh
@@ -28,16 +28,12 @@ chmod +x $PKG_DIR/opt/naturtag/naturtag
 app_version=$(uv run python $SCRIPT_DIR/get_version.py)
 echo "Version: $app_version"
 
-# Build deb, snap, rpm, and pacman packages
+# Build deb, rpm, and pacman packages
 cd $SCRIPT_DIR
 fpm -C $PKG_DIR \
     --version $app_version \
     --output-type deb \
     --package $DIST_DIR/naturtag.deb
-fpm -C $PKG_DIR \
-    --version $app_version \
-    --output-type snap \
-    --package $DIST_DIR/naturtag.snap
 fpm -C $PKG_DIR \
     --version $app_version \
     --output-type rpm \


### PR DESCRIPTION
Closes #476 and #340