### PR TITLE
Add .gitignore entries for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,13 @@ kv/
 libs/
 test-reports/
 venv/
+
+# Secrets and credentials
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+credentials.json
+service-account*.json


### PR DESCRIPTION
The .gitignore is missing entries for `.env` files and private keys (`*.pem`, `*.key`). Added those to help prevent accidental commits of credentials.